### PR TITLE
feat: add no filter option match for region dropdown

### DIFF
--- a/src/components/RegionSelect/RegionSelect.tsx
+++ b/src/components/RegionSelect/RegionSelect.tsx
@@ -1,92 +1,123 @@
-import { useState } from 'react'
+import { useState, useMemo, useCallback } from 'react'
 import Autocomplete from '@mui/material/Autocomplete'
 import TextField from '@mui/material/TextField'
-
-import styles from './RegionSelect.module.scss'
 import { useTranslation } from 'react-i18next'
 
+import styles from './RegionSelect.module.scss'
+
 /** TODO: Replace with actual country data */
-type CountryOption = {
-  group: 'All Data' | 'Countries with Coral Reefs' | 'Coral reef regions'
+type GroupKey = 'all_data' | 'countries_with_coral' | 'coral_reef_regions'
+type GroupName = 'All Data' | 'Countries with Coral Reefs' | 'Coral reef regions'
+
+interface RegionOption {
+  groupKey: GroupKey
+  groupName: GroupName
   label: string
 }
 
-const DEFAULT_OPTION: CountryOption = {
-  group: 'All Data',
+const groupOrders: GroupKey[] = ['all_data', 'countries_with_coral', 'coral_reef_regions']
+
+const defaultOption: RegionOption = {
+  groupKey: 'all_data',
+  groupName: 'All Data',
   label: 'Global',
 }
 
-const countryOptions: CountryOption[] = [
-  { group: 'All Data', label: 'Global' },
-  { group: 'Countries with Coral Reefs', label: 'Antigua and Barbuda' },
-  { group: 'Countries with Coral Reefs', label: 'Australia' },
-  { group: 'Countries with Coral Reefs', label: 'Bahamas' },
-  { group: 'Countries with Coral Reefs', label: 'Barbados' },
-  { group: 'Countries with Coral Reefs', label: 'Belize' },
-  { group: 'Countries with Coral Reefs', label: 'Dominica' },
-  { group: 'Countries with Coral Reefs', label: 'Fiji' },
-  { group: 'Countries with Coral Reefs', label: 'Grenada' },
-  { group: 'Countries with Coral Reefs', label: 'Jamaica' },
-  { group: 'Countries with Coral Reefs', label: 'Malaysia' },
-  { group: 'Countries with Coral Reefs', label: 'New Zealand' },
-  { group: 'Countries with Coral Reefs', label: 'Saint Kitts' },
-  { group: 'Coral reef regions', label: 'Great Barrier Reef' },
-  { group: 'Coral reef regions', label: 'Caribbean Sea' },
-  { group: 'Coral reef regions', label: 'Red Sea' },
-  { group: 'Coral reef regions', label: 'Indo-Pacific' },
-  { group: 'Coral reef regions', label: 'Coral Triangle' },
-  { group: 'Coral reef regions', label: 'Mesoamerican Reef' },
-  { group: 'Coral reef regions', label: 'Hawaiian Archipelago' },
-  { group: 'Coral reef regions', label: 'Ningaloo Reef' },
+const regionOptions: RegionOption[] = [
+  { groupKey: 'all_data', groupName: 'All Data', label: 'Global' },
+  {
+    groupKey: 'countries_with_coral',
+    groupName: 'Countries with Coral Reefs',
+    label: 'Antigua and Barbuda',
+  },
+  { groupKey: 'countries_with_coral', groupName: 'Countries with Coral Reefs', label: 'Australia' },
+  { groupKey: 'countries_with_coral', groupName: 'Countries with Coral Reefs', label: 'Bahamas' },
+  { groupKey: 'countries_with_coral', groupName: 'Countries with Coral Reefs', label: 'Barbados' },
+  { groupKey: 'countries_with_coral', groupName: 'Countries with Coral Reefs', label: 'Belize' },
+  { groupKey: 'countries_with_coral', groupName: 'Countries with Coral Reefs', label: 'Dominica' },
+  { groupKey: 'countries_with_coral', groupName: 'Countries with Coral Reefs', label: 'Fiji' },
+  { groupKey: 'countries_with_coral', groupName: 'Countries with Coral Reefs', label: 'Grenada' },
+  { groupKey: 'countries_with_coral', groupName: 'Countries with Coral Reefs', label: 'Jamaica' },
+  { groupKey: 'countries_with_coral', groupName: 'Countries with Coral Reefs', label: 'Malaysia' },
+  {
+    groupKey: 'countries_with_coral',
+    groupName: 'Countries with Coral Reefs',
+    label: 'New Zealand',
+  },
+  {
+    groupKey: 'countries_with_coral',
+    groupName: 'Countries with Coral Reefs',
+    label: 'Saint Kitts',
+  },
+  { groupKey: 'coral_reef_regions', groupName: 'Coral reef regions', label: 'Great Barrier Reef' },
+  { groupKey: 'coral_reef_regions', groupName: 'Coral reef regions', label: 'Caribbean Sea' },
+  { groupKey: 'coral_reef_regions', groupName: 'Coral reef regions', label: 'Red Sea' },
+  { groupKey: 'coral_reef_regions', groupName: 'Coral reef regions', label: 'Indo-Pacific' },
+  { groupKey: 'coral_reef_regions', groupName: 'Coral reef regions', label: 'Coral Triangle' },
+  { groupKey: 'coral_reef_regions', groupName: 'Coral reef regions', label: 'Mesoamerican Reef' },
+  {
+    groupKey: 'coral_reef_regions',
+    groupName: 'Coral reef regions',
+    label: 'Hawaiian Archipelago',
+  },
+  { groupKey: 'coral_reef_regions', groupName: 'Coral reef regions', label: 'Ningaloo Reef' },
 ]
 /** End of mock data */
 
 export default function RegionSelect() {
   const { t } = useTranslation()
-  const [selectedValue, setSelectedValue] = useState<CountryOption | null>(DEFAULT_OPTION)
+  const [selectedValue, setSelectedValue] = useState<RegionOption | null>(defaultOption)
+  const noCountriesMatchText = t('no_countries_match')
+  const noRegionsMatchText = t('no_regions_match')
 
-  const sortedOptions = countryOptions.sort((a, b) => {
-    const groupOrder = [t('all_data'), t('countries_with_coral'), t('coral_reef_regions')]
+  const sortedOptions = useMemo(() => {
+    return [...regionOptions].sort((a, b) => {
+      if (a.groupKey !== b.groupKey) {
+        const aIndex = groupOrders.indexOf(a.groupKey)
+        const bIndex = groupOrders.indexOf(b.groupKey)
+        return aIndex - bIndex
+      }
+      return a.label.localeCompare(b.label)
+    })
+  }, [])
 
-    if (a.group !== b.group) {
-      const aIndex = groupOrder.indexOf(a.group)
-      const bIndex = groupOrder.indexOf(b.group)
-      return aIndex - bIndex
-    }
-    return a.label.localeCompare(b.label)
-  })
-
-  const handleChange = (_, newValue: CountryOption | null) => {
-    setSelectedValue(newValue || DEFAULT_OPTION)
-  }
-
-  const isOptionEqual = (option: CountryOption, value: CountryOption) => {
-    return option.label === value.label && option.group === value.group
-  }
-
-  const createEmptyFilterOptions = (): CountryOption[] => {
-    const noDataGroupDisplay = [
-      { name: t('countries_with_coral'), label: t('no_countries_match') },
-      { name: t('coral_reef_regions'), label: t('no_regions_match') },
+  const createEmptyFilterOptions = useCallback((): RegionOption[] => {
+    const noDataGroups = [
+      {
+        groupKey: 'countries_with_coral',
+        groupName: 'Countries with Coral Reefs',
+        label: noCountriesMatchText,
+      },
+      {
+        groupKey: 'coral_reef_regions',
+        groupName: 'Coral reef regions',
+        label: noRegionsMatchText,
+      },
     ]
-    return noDataGroupDisplay.map((group) => ({
-      group: group.name as CountryOption['group'],
-      label: group.label,
-    }))
+
+    return noDataGroups as RegionOption[]
+  }, [noCountriesMatchText, noRegionsMatchText])
+
+  const handleChange = (_: unknown, newValue: RegionOption | null) => {
+    setSelectedValue(newValue || defaultOption)
   }
 
   return (
     <div className={styles['RegionSelect-root']}>
-      <Autocomplete
+      <Autocomplete<RegionOption>
         size="small"
         options={sortedOptions}
-        groupBy={(option) => option.group}
+        groupBy={(option) => option.groupName}
         getOptionLabel={(option) => option.label}
-        getOptionDisabled={(option) => option.label.startsWith('No ')}
+        getOptionDisabled={(option) =>
+          option.label === noCountriesMatchText || option.label === noRegionsMatchText
+        }
         aria-label={t('select_region')}
         value={selectedValue}
         onChange={handleChange}
-        isOptionEqualToValue={isOptionEqual}
+        isOptionEqualToValue={(option, value) =>
+          option.label === value.label && option.groupName === value.groupName
+        }
         noOptionsText=""
         filterOptions={(options, { inputValue }) => {
           const filtered = options.filter((option) =>
@@ -113,11 +144,23 @@ export default function RegionSelect() {
           },
         }}
         renderInput={(params) => <TextField {...params} />}
-        renderOption={(props, option) => (
-          <li {...props} style={{ opacity: option.label === 'No data' ? 0.6 : 1 }}>
-            {option.label}
-          </li>
-        )}
+        renderOption={(props, option) => {
+          const { key, ...otherProps } = props
+          return (
+            <li
+              key={key}
+              {...otherProps}
+              style={{
+                opacity:
+                  option.label === noCountriesMatchText || option.label === noRegionsMatchText
+                    ? 0.6
+                    : 1,
+              }}
+            >
+              {option.label}
+            </li>
+          )
+        }}
         renderGroup={(params) => (
           <li key={params.key}>
             <div className={styles['group-header']}>{params.group}</div>

--- a/src/components/RegionSelect/RegionSelect.tsx
+++ b/src/components/RegionSelect/RegionSelect.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo, useCallback } from 'react'
-import Autocomplete from '@mui/material/Autocomplete'
+import Autocomplete, { createFilterOptions } from '@mui/material/Autocomplete'
 import TextField from '@mui/material/TextField'
 import { useTranslation } from 'react-i18next'
 
@@ -81,6 +81,8 @@ export default function RegionSelect() {
     })
   }, [])
 
+  const muiFilterOptions = createFilterOptions<RegionOption>({ ignoreAccents: true, trim: true })
+
   const createEmptyFilterOptions = useCallback((): RegionOption[] => {
     const noDataGroups = [
       {
@@ -107,7 +109,7 @@ export default function RegionSelect() {
       <Autocomplete<RegionOption>
         size="small"
         options={sortedOptions}
-        groupBy={(option) => option.groupName}
+        groupBy={(option) => t(option.groupKey)}
         getOptionLabel={(option) => option.label}
         getOptionDisabled={(option) =>
           option.label === noCountriesMatchText || option.label === noRegionsMatchText
@@ -116,19 +118,12 @@ export default function RegionSelect() {
         value={selectedValue}
         onChange={handleChange}
         isOptionEqualToValue={(option, value) =>
-          option.label === value.label && option.groupName === value.groupName
+          option.label === value.label && option.groupKey === value.groupKey
         }
         noOptionsText=""
-        filterOptions={(options, { inputValue }) => {
-          const filtered = options.filter((option) =>
-            option.label.toLowerCase().includes(inputValue.toLowerCase()),
-          )
-
-          if (filtered.length === 0) {
-            return createEmptyFilterOptions()
-          }
-
-          return filtered
+        filterOptions={(options, state) => {
+          const filtered = muiFilterOptions(options, state)
+          return filtered.length ? filtered : createEmptyFilterOptions()
         }}
         classes={{
           root: styles['MuiAutocomplete-root'],

--- a/src/components/RegionSelect/RegionSelect.tsx
+++ b/src/components/RegionSelect/RegionSelect.tsx
@@ -7,7 +7,7 @@ import { useTranslation } from 'react-i18next'
 
 /** TODO: Replace with actual country data */
 type CountryOption = {
-  group: 'All Data' | 'Countries with Coral Reefs'
+  group: 'All Data' | 'Countries with Coral Reefs' | 'Coral reef regions'
   label: string
 }
 
@@ -30,6 +30,14 @@ const countryOptions: CountryOption[] = [
   { group: 'Countries with Coral Reefs', label: 'Malaysia' },
   { group: 'Countries with Coral Reefs', label: 'New Zealand' },
   { group: 'Countries with Coral Reefs', label: 'Saint Kitts' },
+  { group: 'Coral reef regions', label: 'Great Barrier Reef' },
+  { group: 'Coral reef regions', label: 'Caribbean Sea' },
+  { group: 'Coral reef regions', label: 'Red Sea' },
+  { group: 'Coral reef regions', label: 'Indo-Pacific' },
+  { group: 'Coral reef regions', label: 'Coral Triangle' },
+  { group: 'Coral reef regions', label: 'Mesoamerican Reef' },
+  { group: 'Coral reef regions', label: 'Hawaiian Archipelago' },
+  { group: 'Coral reef regions', label: 'Ningaloo Reef' },
 ]
 /** End of mock data */
 
@@ -38,8 +46,12 @@ export default function RegionSelect() {
   const [selectedValue, setSelectedValue] = useState<CountryOption | null>(DEFAULT_OPTION)
 
   const sortedOptions = countryOptions.sort((a, b) => {
+    const groupOrder = [t('all_data'), t('countries_with_coral'), t('coral_reef_regions')]
+
     if (a.group !== b.group) {
-      return a.group.localeCompare(b.group)
+      const aIndex = groupOrder.indexOf(a.group)
+      const bIndex = groupOrder.indexOf(b.group)
+      return aIndex - bIndex
     }
     return a.label.localeCompare(b.label)
   })
@@ -52,6 +64,17 @@ export default function RegionSelect() {
     return option.label === value.label && option.group === value.group
   }
 
+  const createEmptyFilterOptions = (): CountryOption[] => {
+    const noDataGroupDisplay = [
+      { name: t('countries_with_coral'), label: t('no_countries_match') },
+      { name: t('coral_reef_regions'), label: t('no_regions_match') },
+    ]
+    return noDataGroupDisplay.map((group) => ({
+      group: group.name as CountryOption['group'],
+      label: group.label,
+    }))
+  }
+
   return (
     <div className={styles['RegionSelect-root']}>
       <Autocomplete
@@ -59,10 +82,23 @@ export default function RegionSelect() {
         options={sortedOptions}
         groupBy={(option) => option.group}
         getOptionLabel={(option) => option.label}
+        getOptionDisabled={(option) => option.label.startsWith('No ')}
         aria-label={t('select_region')}
         value={selectedValue}
         onChange={handleChange}
         isOptionEqualToValue={isOptionEqual}
+        noOptionsText=""
+        filterOptions={(options, { inputValue }) => {
+          const filtered = options.filter((option) =>
+            option.label.toLowerCase().includes(inputValue.toLowerCase()),
+          )
+
+          if (filtered.length === 0) {
+            return createEmptyFilterOptions()
+          }
+
+          return filtered
+        }}
         classes={{
           root: styles['MuiAutocomplete-root'],
           input: styles['MuiAutocomplete-input'],
@@ -77,6 +113,11 @@ export default function RegionSelect() {
           },
         }}
         renderInput={(params) => <TextField {...params} />}
+        renderOption={(props, option) => (
+          <li {...props} style={{ opacity: option.label === 'No data' ? 0.6 : 1 }}>
+            {option.label}
+          </li>
+        )}
         renderGroup={(params) => (
           <li key={params.key}>
             <div className={styles['group-header']}>{params.group}</div>

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -71,5 +71,7 @@
   "year": "Year",
   "toggle_navigation_menu": "Toggle navigation menu",
   "select_region": "Select region",
-  "select_year": "Select year"
+  "select_year": "Select year",
+  "no_countries_match": "No countries match your filter",
+  "no_regions_match": "No regions match your filter"
 }


### PR DESCRIPTION

## Every PR

Before merging, the developer of this pull request has checked the following:

- [x] Changes have been tested locally without errors
- [x] Lint has run and any errors have been resolved
- [x] Prettier has run on any changed files
- [x] Unit tests have been added or updated, where possible, to prevent future regressions
- [x] Pre-existing unit tests have run and passed

## Post-Merge

- [ ] Code has merged and build success is confirmed in 'Actions'
- [ ] The corresponding Trello ticket has moved to the appropriate list (likely User-QA)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Switched to region-centric options, adding a "Coral reef regions" group, multiple reef region entries, and a retained Global option.
  - Search now shows translated placeholder entries when no matches are found.

- Refactor
  - Sorting now enforces a stable group order and sorts items by label within groups.
  - Autocomplete updated to group by region, disable placeholders, clear default "no options" text, and visually de-emphasize placeholder items.

- Chores
  - Added translation keys for "no countries match" and "no regions match."
<!-- end of auto-generated comment: release notes by coderabbit.ai -->