### PR TITLE
feat: [C88-D1] implement year selection URL query parameter and context

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "react-dom": "^19.1.0",
     "react-i18next": "^15.6.0",
     "react-map-gl": "^8.0.4",
-    "react-plotly.js": "^2.6.0"
+    "react-plotly.js": "^2.6.0",
+    "react-router-dom": "^7.8.2"
   },
   "devDependencies": {
     "@chromatic-com/storybook": "4.0.1",

--- a/src/components/MapContainer/MapContainer.tsx
+++ b/src/components/MapContainer/MapContainer.tsx
@@ -10,7 +10,6 @@ import { layers } from '../../data/mapData'
 
 export default function MapContainer() {
   const { isMobileWidth } = useResponsive()
-  const [selectedYear, setSelectedYear] = useState(2020)
   const [layersOn, setLayersOn] = useState(layers)
 
   return (
@@ -19,7 +18,7 @@ export default function MapContainer() {
         <div className={styles['layer-controls--mobile']}>
           <LayersDrawer layersOn={layersOn} setLayersOn={setLayersOn} />
           <RegionSelect />
-          <YearSelect selectedYear={selectedYear} onChange={setSelectedYear} />
+          <YearSelect />
           <TrendsDrawer />
         </div>
       ) : (
@@ -27,7 +26,7 @@ export default function MapContainer() {
           <LayersDrawer layersOn={layersOn} setLayersOn={setLayersOn} />
           <div>
             <RegionSelect />
-            <YearSelect selectedYear={selectedYear} onChange={setSelectedYear} />
+            <YearSelect />
           </div>
           <TrendsDrawer />
         </div>

--- a/src/components/YearSelect/YearSelect.module.scss
+++ b/src/components/YearSelect/YearSelect.module.scss
@@ -14,13 +14,17 @@
     border-radius: theme.$borderRadius;
     transition: all 0.2s ease-in-out;
 
+    &:hover {
+      border-color: theme.$black;
+    }
+
     @include theme.mobileDownBreakPoint {
       font-size: theme.$textSizeSmall !important;
     }
   }
 
   .dropdown__button--disabled {
-    opacity: 0.6;
+    opacity: 0.7;
     cursor: not-allowed;
   }
 

--- a/src/components/YearSelect/YearSelect.stories.tsx
+++ b/src/components/YearSelect/YearSelect.stories.tsx
@@ -1,36 +1,31 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
-import { useState } from 'react'
 import YearSelect from './YearSelect'
+import { BrowserRouter } from 'react-router-dom'
+import { FilterSelectProvider } from '../../contexts/FilterSelectProvider'
 
 const meta: Meta<typeof YearSelect> = {
   title: 'Components/YearSelect',
   component: YearSelect,
   parameters: { layout: 'centered' },
+  decorators: [
+    (Story) => (
+      <BrowserRouter>
+        <FilterSelectProvider>
+          <Story />
+        </FilterSelectProvider>
+      </BrowserRouter>
+    ),
+  ],
 }
 
 type Story = StoryObj<typeof YearSelect>
 
-const StoryBookYearSelect = (props: React.ComponentProps<typeof YearSelect>) => {
-  const { selectedYear: initialSelectedYear = 2020, onChange, ...rest } = props
-  const [selectedYear, setSelectedYear] = useState<number>(initialSelectedYear)
-
-  const handleChange = (year: number) => {
-    setSelectedYear(year)
-    onChange?.(year)
-  }
-
-  return <YearSelect selectedYear={selectedYear} onChange={handleChange} {...rest} />
-}
-
 export const Primary: Story = {
-  render: (args) => <StoryBookYearSelect {...args} />,
-  args: { selectedYear: 2020 },
+  args: {},
 }
 
 export const Disabled: Story = {
-  render: (args) => <StoryBookYearSelect {...args} />,
   args: {
-    selectedYear: 2020,
     disabled: true,
   },
 }

--- a/src/components/YearSelect/YearSelect.tsx
+++ b/src/components/YearSelect/YearSelect.tsx
@@ -7,23 +7,17 @@ import clsx from 'clsx'
 
 import styles from './YearSelect.module.scss'
 import { useTranslation } from 'react-i18next'
-
-const availableYears = [2020, 2015, 2010, 2005, 2000]
+import { availableYears } from '../../constants'
+import { useFilterSelect } from '../../contexts/FilterSelectContext'
 
 export interface YearSelectProps {
-  selectedYear: number
-  onChange?: (year: number) => void
   className?: string
   disabled?: boolean
 }
 
-export const YearSelect = ({
-  selectedYear,
-  onChange,
-  className,
-  disabled = false,
-}: YearSelectProps) => {
+export const YearSelect = ({ className, disabled = false }: YearSelectProps) => {
   const { t } = useTranslation()
+  const { selectedYear, updateSelectedYear } = useFilterSelect()
   const [isOpen, setIsOpen] = useState(false)
   const containerRef = useRef<HTMLDivElement>(null)
 
@@ -32,14 +26,6 @@ export const YearSelect = ({
       setIsOpen((prev) => !prev)
     }
   }, [disabled])
-
-  const handleYearSelect = useCallback(
-    (year: number) => {
-      onChange?.(year)
-      setIsOpen(false)
-    },
-    [onChange],
-  )
 
   const handleCloseDropdown = useCallback(() => {
     setIsOpen(false)
@@ -91,7 +77,7 @@ export const YearSelect = ({
             return (
               <ListItem key={year} disablePadding>
                 <Button
-                  onClick={() => handleYearSelect(year)}
+                  onClick={() => updateSelectedYear(year)}
                   className={clsx(
                     styles['dropdown__option'],
                     isSelected && styles['dropdown__option--selected'],

--- a/src/components/YearSelect/YearSelect.tsx
+++ b/src/components/YearSelect/YearSelect.tsx
@@ -56,7 +56,7 @@ export const YearSelect = ({ className, disabled = false }: YearSelectProps) => 
     <Box ref={containerRef} className={clsx(styles['dropdown'], className)}>
       <Button
         size="small"
-        variant="contained"
+        variant="outlined"
         aria-label={t('select_year')}
         disabled={disabled}
         onClick={handleToggleDropdown}

--- a/src/components/YearSelect/YearSelect.tsx
+++ b/src/components/YearSelect/YearSelect.tsx
@@ -8,7 +8,7 @@ import clsx from 'clsx'
 import styles from './YearSelect.module.scss'
 import { useTranslation } from 'react-i18next'
 import { availableYears } from '../../constants'
-import { useFilterSelect } from '../../contexts/FilterSelectContext'
+import { useFilterSelect } from '../../hooks/useGlobalContext'
 
 export interface YearSelectProps {
   className?: string

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,3 +4,5 @@ export const REGIONS_URL =
 
 export const GLOBAL_LULC_URL =
   'https://gpw-coastal-pollution-model-data-public-0001.s3.ap-southeast-2.amazonaws.com/outputs/land/global/global_lulc/lulc_2000_visual.tif'
+
+export const availableYears = ['2020', '2015', '2010', '2005', '2000']

--- a/src/contexts/FilterSelectContext.tsx
+++ b/src/contexts/FilterSelectContext.tsx
@@ -1,0 +1,71 @@
+import React, { createContext, useState, useEffect, useCallback } from 'react'
+import { useSearchParams } from 'react-router-dom'
+import { getDefaultYear, isValidYear } from '../utils/yearValidation'
+
+interface FilterSelectContextType {
+  selectedYear: string
+  updateSelectedYear: (year: string) => void
+}
+
+const FilterSelectContext = createContext<FilterSelectContextType | undefined>(undefined)
+
+interface FilterSelectProviderProps {
+  children: React.ReactNode
+}
+
+const latestYear = getDefaultYear
+
+export const FilterSelectProvider = ({ children }: FilterSelectProviderProps) => {
+  const [searchParams, setSearchParams] = useSearchParams()
+  const [selectedYear, setSelectedYear] = useState<string>(latestYear)
+
+  // Initialize and sync with URL params
+  useEffect(() => {
+    const yearSearchParam = searchParams.get('year')
+
+    // No year in URL - use default
+    if (!yearSearchParam) {
+      setSelectedYear(latestYear)
+      return
+    }
+
+    // Valid year in URL - use it
+    if (isValidYear(yearSearchParam)) {
+      setSelectedYear(yearSearchParam)
+      return
+    }
+
+    // Invalid year in URL - reset to default and clean URL
+    setSelectedYear(latestYear)
+    setSearchParams({}, { replace: true })
+  }, [searchParams, setSearchParams])
+
+  const updateSelectedYear = useCallback(
+    (year: string) => {
+      if (!isValidYear(year)) return
+
+      setSelectedYear(year)
+      setSearchParams({ year }, { replace: true })
+    },
+    [setSearchParams],
+  )
+
+  const contextValue: FilterSelectContextType = {
+    selectedYear,
+    updateSelectedYear,
+  }
+
+  return (
+    <FilterSelectContext.Provider value={contextValue}>{children}</FilterSelectContext.Provider>
+  )
+}
+
+export const useFilterSelect = () => {
+  const context = React.useContext(FilterSelectContext)
+
+  if (context === undefined) {
+    throw new Error('useFilterSelect must be used within a FilterSelectProvider')
+  }
+
+  return context
+}

--- a/src/contexts/FilterSelectContext.tsx
+++ b/src/contexts/FilterSelectContext.tsx
@@ -1,71 +1,8 @@
-import React, { createContext, useState, useEffect, useCallback } from 'react'
-import { useSearchParams } from 'react-router-dom'
-import { getDefaultYear, isValidYear } from '../utils/yearValidation'
+import { createContext } from 'react'
 
-interface FilterSelectContextType {
+export interface FilterSelectContextType {
   selectedYear: string
   updateSelectedYear: (year: string) => void
 }
 
-const FilterSelectContext = createContext<FilterSelectContextType | undefined>(undefined)
-
-interface FilterSelectProviderProps {
-  children: React.ReactNode
-}
-
-const latestYear = getDefaultYear
-
-export const FilterSelectProvider = ({ children }: FilterSelectProviderProps) => {
-  const [searchParams, setSearchParams] = useSearchParams()
-  const [selectedYear, setSelectedYear] = useState<string>(latestYear)
-
-  // Initialize and sync with URL params
-  useEffect(() => {
-    const yearSearchParam = searchParams.get('year')
-
-    // No year in URL - use default
-    if (!yearSearchParam) {
-      setSelectedYear(latestYear)
-      return
-    }
-
-    // Valid year in URL - use it
-    if (isValidYear(yearSearchParam)) {
-      setSelectedYear(yearSearchParam)
-      return
-    }
-
-    // Invalid year in URL - reset to default and clean URL
-    setSelectedYear(latestYear)
-    setSearchParams({}, { replace: true })
-  }, [searchParams, setSearchParams])
-
-  const updateSelectedYear = useCallback(
-    (year: string) => {
-      if (!isValidYear(year)) return
-
-      setSelectedYear(year)
-      setSearchParams({ year }, { replace: true })
-    },
-    [setSearchParams],
-  )
-
-  const contextValue: FilterSelectContextType = {
-    selectedYear,
-    updateSelectedYear,
-  }
-
-  return (
-    <FilterSelectContext.Provider value={contextValue}>{children}</FilterSelectContext.Provider>
-  )
-}
-
-export const useFilterSelect = () => {
-  const context = React.useContext(FilterSelectContext)
-
-  if (context === undefined) {
-    throw new Error('useFilterSelect must be used within a FilterSelectProvider')
-  }
-
-  return context
-}
+export const FilterSelectContext = createContext<FilterSelectContextType | undefined>(undefined)

--- a/src/contexts/FilterSelectProvider.tsx
+++ b/src/contexts/FilterSelectProvider.tsx
@@ -1,0 +1,56 @@
+import React, { useState, useEffect, useCallback } from 'react'
+import { useSearchParams } from 'react-router-dom'
+import { getDefaultYear, isValidYear } from '../utils/yearValidation'
+import { FilterSelectContext, FilterSelectContextType } from './FilterSelectContext'
+
+interface FilterSelectProviderProps {
+  children: React.ReactNode
+}
+
+const latestYear = getDefaultYear
+
+export const FilterSelectProvider = ({ children }: FilterSelectProviderProps) => {
+  const [searchParams, setSearchParams] = useSearchParams()
+  const [selectedYear, setSelectedYear] = useState<string>(latestYear)
+
+  useEffect(() => {
+    const yearSearchParam = searchParams.get('year')
+
+    // No year in URL - use default
+    if (!yearSearchParam) {
+      setSelectedYear(latestYear)
+      return
+    }
+
+    // Valid year in URL - use it
+    if (isValidYear(yearSearchParam)) {
+      setSelectedYear(yearSearchParam)
+      return
+    }
+
+    // Invalid year in URL - reset to default and clean URL
+    setSelectedYear(latestYear)
+    setSearchParams({}, { replace: true })
+  }, [searchParams, setSearchParams])
+
+  const updateSelectedYear = useCallback(
+    (year: string) => {
+      if (!isValidYear(year)) {
+        return
+      }
+
+      setSelectedYear(year)
+      setSearchParams({ year }, { replace: true })
+    },
+    [setSearchParams],
+  )
+
+  const contextValue: FilterSelectContextType = {
+    selectedYear,
+    updateSelectedYear,
+  }
+
+  return (
+    <FilterSelectContext.Provider value={contextValue}>{children}</FilterSelectContext.Provider>
+  )
+}

--- a/src/hooks/useGlobalContext.ts
+++ b/src/hooks/useGlobalContext.ts
@@ -1,0 +1,13 @@
+// Custom hooks for all app contexts
+import { useContext } from 'react'
+import { FilterSelectContext } from '../contexts/FilterSelectContext'
+
+export const useFilterSelect = () => {
+  const context = useContext(FilterSelectContext)
+
+  if (context === undefined) {
+    throw new Error('useFilterSelect must be used within a FilterSelectProvider')
+  }
+
+  return context
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,7 +7,7 @@ import { StyledEngineProvider } from '@mui/material'
 import '../i18n'
 import MapContainer from './components/MapContainer/MapContainer'
 import NavigationHeader from './components/NavigationHeader/NavigationHeader'
-import { FilterSelectProvider } from './contexts/FilterSelectContext'
+import { FilterSelectProvider } from './contexts/FilterSelectProvider'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,17 +1,23 @@
 import React, { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { BrowserRouter } from 'react-router-dom'
 import './styles/reset.module.scss'
 import './styles/index.module.scss'
 import { StyledEngineProvider } from '@mui/material'
 import '../i18n'
 import MapContainer from './components/MapContainer/MapContainer'
 import NavigationHeader from './components/NavigationHeader/NavigationHeader'
+import { FilterSelectProvider } from './contexts/FilterSelectContext'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <StyledEngineProvider injectFirst>
-      <NavigationHeader />
-      <MapContainer />
-    </StyledEngineProvider>
+    <BrowserRouter>
+      <StyledEngineProvider injectFirst>
+        <FilterSelectProvider>
+          <NavigationHeader />
+          <MapContainer />
+        </FilterSelectProvider>
+      </StyledEngineProvider>
+    </BrowserRouter>
   </StrictMode>,
 )

--- a/src/styles/theme.scss
+++ b/src/styles/theme.scss
@@ -6,6 +6,7 @@ $secondaryLight: #f5f5f5;
 $white: #ffffff;
 $grey: #dedfe3;
 $greyWhite: #fafbfc;
+$black: #000000;
 
 /** Fonts, font styling, text **/
 $textColor: #393939;

--- a/src/utils/yearValidation.ts
+++ b/src/utils/yearValidation.ts
@@ -1,0 +1,9 @@
+import { availableYears } from '../constants'
+
+export const isValidYear = (year: string): boolean => {
+  return availableYears.includes(year)
+}
+
+export const getDefaultYear = (): string => {
+  return availableYears[0]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3072,6 +3072,11 @@ convert-source-map@^2.0.0:
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-2.0.0.tgz#4b560f649fc4e918dd0ab75cf4961e8bc882d82a"
   integrity sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==
 
+cookie@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-1.0.2.tgz#27360701532116bd3f1f9416929d176afe1e4610"
+  integrity sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==
+
 core-util-is@~1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
@@ -6543,6 +6548,21 @@ react-refresh@^0.17.0:
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.17.0.tgz#b7e579c3657f23d04eccbe4ad2e58a8ed51e7e53"
   integrity sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==
 
+react-router-dom@^7.8.2:
+  version "7.8.2"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-7.8.2.tgz#25a8fc36588189baf3bbb5e360c8ffffbd2beabc"
+  integrity sha512-Z4VM5mKDipal2jQ385H6UBhiiEDlnJPx6jyWsTYoZQdl5TrjxEV2a9yl3Fi60NBJxYzOTGTTHXPi0pdizvTwow==
+  dependencies:
+    react-router "7.8.2"
+
+react-router@7.8.2:
+  version "7.8.2"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-7.8.2.tgz#9d2d4147ca72832c550acc60ed688062d18f70b8"
+  integrity sha512-7M2fR1JbIZ/jFWqelpvSZx+7vd7UlBTfdZqf6OSdF9g6+sfdqJDAWcak6ervbHph200ePlu+7G8LdoiC3ReyAQ==
+  dependencies:
+    cookie "^1.0.1"
+    set-cookie-parser "^2.6.0"
+
 react-transition-group@^4.4.5:
   version "4.4.5"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.5.tgz#e53d4e3f3344da8521489fbef8f2581d42becdd1"
@@ -6979,6 +6999,11 @@ semver@^7.5.3, semver@^7.5.4, semver@^7.6.0, semver@^7.6.2, semver@^7.7.2:
   version "7.7.2"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.2.tgz#67d99fdcd35cec21e6f8b87a7fd515a33f982b58"
   integrity sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==
+
+set-cookie-parser@^2.6.0:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz#3016f150072202dfbe90fadee053573cc89d2943"
+  integrity sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==
 
 set-function-length@^1.2.2:
   version "1.2.2"


### PR DESCRIPTION

## Every PR

Before merging, the developer of this pull request has checked the following:

- [ ] Changes have been tested locally without errors
- [ ] Lint has run and any errors have been resolved
- [ ] Prettier has run on any changed files
- [ ] Unit tests have been added or updated, where possible, to prevent future regressions
- [ ] Pre-existing unit tests have run and passed

## Post-Merge

- [ ] Code has merged and build success is confirmed in 'Actions'
- [ ] The corresponding Trello ticket has moved to the appropriate list (likely User-QA)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added URL-based routing (browser back/forward support).
  - Introduced a global year filter synced to the URL; invalid years reset to a default.
  - Year selector now uses a shared list of years (2020, 2015, 2010, 2005, 2000) and is driven by global state.
  - Selecting a year no longer auto-closes the dropdown (close via outside click or Escape).

- Style
  - Dropdown button hover and disabled appearance updated; new theme color introduced.

- Chores
  - Added routing dependency to enable navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->