### PR TITLE
feat: [C103] Graph No data or error state

### DIFF
--- a/src/components/GraphCard/GraphCard.module.scss
+++ b/src/components/GraphCard/GraphCard.module.scss
@@ -46,3 +46,13 @@
   font-weight: theme.$bold;
   line-height: 1.2;
 }
+
+.no-data-label {
+  font-size: theme.$textSizeSmall;
+  font-weight: theme.$light;
+  font-style: italic;
+  line-height: 1.2;
+  color: theme.$textSecondary;
+  margin-top: theme.$defaultSpacing;
+  padding-top: theme.$defaultSpacing;
+}

--- a/src/components/GraphCard/GraphCard.stories.tsx
+++ b/src/components/GraphCard/GraphCard.stories.tsx
@@ -1,77 +1,27 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
 
 import GraphCard from './GraphCard'
-import { ChartedData } from '../../utils/updateGraph'
+import { mockGraphData } from '../../data/mapData'
 
 const meta = {
   component: GraphCard,
 } satisfies Meta<typeof GraphCard>
 
 type Story = StoryObj<typeof meta>
-export const MockGraphData: ChartedData[] = [
-  {
-    x: ['2000', '2005', '2010', '2015', '2020'],
-    y: [16, 14, 14, 10, 4],
-    name: 'Bare Ground',
-    type: 'bar',
-    width: 3,
-  },
-  {
-    x: ['2000', '2005', '2010', '2015', '2020'],
-    y: [18, 17, 16, 16, 17],
-    name: 'Shrub',
-    type: 'bar',
-    width: 3,
-  },
-  {
-    x: ['2000', '2005', '2010', '2015', '2020'],
-    y: [16, 14, 2, 4, 17],
-    name: 'Surface water',
-    type: 'bar',
-    width: 3,
-  },
-  {
-    x: ['2000', '2005', '2010', '2015', '2020'],
-    y: [3, 8, 13, 15, 20],
-    name: 'Built-up',
-    type: 'bar',
-    width: 3,
-  },
-  {
-    x: ['2000', '2005', '2010', '2015', '2020'],
-    y: [18, 18, 18, 17, 14],
-    name: 'High canopy forest',
-    type: 'bar',
-    width: 3,
-  },
-  {
-    x: ['2000', '2005', '2010', '2015', '2020'],
-    y: [15, 14, 17, 20, 18],
-    name: 'Cropland',
-    type: 'bar',
-    width: 3,
-  },
-  {
-    x: ['2000', '2005', '2010', '2015', '2020'],
-    y: [15, 14, 12, 10, 10],
-    name: 'Mixed forest',
-    type: 'bar',
-    width: 3,
-  },
-]
+
 export const Primary: Story = {
   args: {
     open: true,
     graphName: 'Primary graph card',
-    graphData: MockGraphData,
+    graphData: mockGraphData,
   },
 }
 
-export const Closed: Story = {
+export const NoData: Story = {
   args: {
     open: false,
-    graphName: 'Closed graph card',
-    graphData: MockGraphData,
+    graphName: 'No data graph card',
+    graphData: null,
   },
 }
 

--- a/src/components/GraphCard/GraphCard.tsx
+++ b/src/components/GraphCard/GraphCard.tsx
@@ -26,32 +26,35 @@ export default function GraphCard({
   graphName,
 }: GraphCardProps) {
   const { t } = useTranslation()
+  const isGraphDataAvailable = open && graphData && graphData.length > 0
+
   return (
-    graphData && (
-      <Card
-        {...(onClick ? { onClick: onClick } : {})}
-        classes={{
-          root: styles[`graph-card--${open ? 'open' : 'closed'}`],
-        }}
-      >
-        <div className={styles[`labels-container--${open ? 'open' : 'closed'}`]}>
-          <Typography className={styles['region-label']}>{t(region)}</Typography>
-          <Typography className={styles['graph-label']}>{t(graphName)}</Typography>
-        </div>
-        {open && (
-          <Plot
-            data={graphData}
-            className={styles['graph-plots']}
-            config={plotlyTheme.config}
-            layout={{
-              ...plotlyTheme.layout,
-              yaxis: { title: { text: t(yAxisTitle), ...plotlyTheme.layout.yaxis.title } },
-              xaxis: { title: { text: t(xAxisTitle), ...plotlyTheme.layout.xaxis.title } },
-            }}
-            style={{ width: '100%', height: '100%' }}
-          />
+    <Card
+      {...(onClick ? { onClick: onClick } : {})}
+      classes={{
+        root: styles[`graph-card--${isGraphDataAvailable ? 'open' : 'closed'}`],
+      }}
+    >
+      <div className={styles[`labels-container--${isGraphDataAvailable ? 'open' : 'closed'}`]}>
+        <Typography className={styles['region-label']}>{t(region)}</Typography>
+        <Typography className={styles['graph-label']}>{t(graphName)}</Typography>
+        {!isGraphDataAvailable && (
+          <Typography className={styles['no-data-label']}>{t('no_graph_data')}</Typography>
         )}
-      </Card>
-    )
+      </div>
+      {isGraphDataAvailable && (
+        <Plot
+          data={graphData}
+          className={styles['graph-plots']}
+          config={plotlyTheme.config}
+          layout={{
+            ...plotlyTheme.layout,
+            yaxis: { title: { text: t(yAxisTitle), ...plotlyTheme.layout.yaxis.title } },
+            xaxis: { title: { text: t(xAxisTitle), ...plotlyTheme.layout.xaxis.title } },
+          }}
+          style={{ width: '100%', height: '100%' }}
+        />
+      )}
+    </Card>
   )
 }

--- a/src/components/TrendsDrawer/TrendsDrawer.tsx
+++ b/src/components/TrendsDrawer/TrendsDrawer.tsx
@@ -1,6 +1,6 @@
+import * as React from 'react'
 import { IconButton } from '@mui/material'
 import { useTranslation } from 'react-i18next'
-import * as React from 'react'
 import { useState } from 'react'
 import CloseIcon from '@mui/icons-material/Close'
 import styles from './TrendsDrawer.module.scss'
@@ -8,7 +8,7 @@ import useResponsive from '../../hooks/useResponsive'
 import StyledSwipeableDrawer from '../StyledSwipeableDrawer/StyledSwipeableDrawer'
 import GraphCard from '../GraphCard/GraphCard'
 import { ChartedData } from '../../utils/updateGraph'
-import { MockGraphData } from '../GraphCard/GraphCard.stories'
+import { mockGraphData } from '../../data/mapData'
 
 interface TrendsDrawerProps {
   // layersOn: LayerInfo[] //todo: show graphs available based on layers on
@@ -51,13 +51,13 @@ export default function TrendsDrawer({ lulcGraphData }: TrendsDrawerProps) {
           open={open}
           {...(isMobileWidth && !open ? { onClick: openDrawer } : {})}
           graphName={'graphs.ecosystem_extent_exposed'}
-          graphData={MockGraphData}
+          graphData={mockGraphData}
         />
         <GraphCard
           open={open}
           {...(isMobileWidth && !open ? { onClick: openDrawer } : {})}
           graphName={'graphs.sediment_exposure_historical'}
-          graphData={MockGraphData}
+          graphData={mockGraphData}
         />
       </div>
     </StyledSwipeableDrawer>

--- a/src/data/mapData.ts
+++ b/src/data/mapData.ts
@@ -4,6 +4,7 @@ import {
   REGIONS_PMTILES_URL,
   WATERSHED_PMTILES_URL,
 } from '../constants'
+import { ChartedData } from '../utils/updateGraph'
 
 export interface LayerInfo {
   sourceId: string
@@ -84,3 +85,55 @@ export const graphLayoutConfig = {
   },
   //...for all graphs
 }
+
+export const mockGraphData: ChartedData[] = [
+  {
+    x: ['2000', '2005', '2010', '2015', '2020'],
+    y: [16, 14, 14, 10, 4],
+    name: 'Bare Ground',
+    type: 'bar',
+    width: 3,
+  },
+  {
+    x: ['2000', '2005', '2010', '2015', '2020'],
+    y: [18, 17, 16, 16, 17],
+    name: 'Shrub',
+    type: 'bar',
+    width: 3,
+  },
+  {
+    x: ['2000', '2005', '2010', '2015', '2020'],
+    y: [16, 14, 2, 4, 17],
+    name: 'Surface water',
+    type: 'bar',
+    width: 3,
+  },
+  {
+    x: ['2000', '2005', '2010', '2015', '2020'],
+    y: [3, 8, 13, 15, 20],
+    name: 'Built-up',
+    type: 'bar',
+    width: 3,
+  },
+  {
+    x: ['2000', '2005', '2010', '2015', '2020'],
+    y: [18, 18, 18, 17, 14],
+    name: 'High canopy forest',
+    type: 'bar',
+    width: 3,
+  },
+  {
+    x: ['2000', '2005', '2010', '2015', '2020'],
+    y: [15, 14, 17, 20, 18],
+    name: 'Cropland',
+    type: 'bar',
+    width: 3,
+  },
+  {
+    x: ['2000', '2005', '2010', '2015', '2020'],
+    y: [15, 14, 12, 10, 10],
+    name: 'Mixed forest',
+    type: 'bar',
+    width: 3,
+  },
+]

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -77,5 +77,6 @@
   "select_region": "Select region",
   "select_year": "Select year",
   "no_countries_match": "No countries match your search",
-  "no_regions_match": "No regions match your search"
+  "no_regions_match": "No regions match your search",
+  "no_graph_data": "No data available for this graph"
 }


### PR DESCRIPTION
## Every PR

Before merging, the developer of this pull request has checked the following:

- [ ] Changes have been tested locally without errors
- [ ] Lint has run and any errors have been resolved
- [ ] Prettier has run on any changed files
- [ ] Storybook stories have run and any errors have been resolved
- [ ] Unit tests have been added or updated, where possible, to prevent future regressions
- [ ] Pre-existing unit tests have run and passed

## Post-Merge

- [ ] Code has merged and build success is confirmed in 'Actions'
- [ ] The corresponding Trello ticket has moved to the appropriate list (likely User-QA)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Graph cards now display a clear “No data available for this graph” message when no data is present.
  - Added English translation for the new message.
- Style
  - Introduced styling for the no-data message to improve readability and hierarchy.
- Refactor
  - Graph cards now render consistently and switch between graph or no-data views based on data availability.
- Chores
  - Updated demo/sample graph data and stories used in the app demos.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->