### PR TITLE
feat: [C94] Ensure custom layers appear below all labels in BaseMap

### DIFF
--- a/src/components/BaseMap/BaseMap.tsx
+++ b/src/components/BaseMap/BaseMap.tsx
@@ -169,6 +169,7 @@ export default function BaseMap({
                     key={`${layer.layerId}-${index}`}
                     source={layer.sourceId}
                     source-layer={layer.sourceName}
+                    beforeId="label_airport" // label_airport is one of the first label layers, this ensures custom layers appear below all labels
                     paint={{
                       'fill-color': 'red',
                       'fill-opacity': 0.25, //needs fill to be able to select individual watersheds
@@ -192,6 +193,7 @@ export default function BaseMap({
                     type="raster"
                     key={`${layer.layerId}-${index}`}
                     source={layer.sourceId}
+                    beforeId="label_airport" // label_airport is one of the first label layers, this ensures custom layers appear below all labels
                   />
                 </Source>
               )


### PR DESCRIPTION
## Every PR

Before merging, the developer of this pull request has checked the following:

- [ ] Changes have been tested locally without errors
- [ ] Lint has run and any errors have been resolved
- [ ] Prettier has run on any changed files
- [ ] Storybook stories have run and any errors have been resolved
- [ ] Unit tests have been added or updated, where possible, to prevent future regressions
- [ ] Pre-existing unit tests have run and passed

## Post-Merge

- [ ] Code has merged and build success is confirmed in 'Actions'
- [ ] The corresponding Trello ticket has moved to the appropriate list (likely User-QA)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected map layer stacking so custom layers render beneath label layers (e.g., airports), preserving label visibility.
  * Applied consistently across both vector and raster base maps for uniform behavior.
  * Improves map readability and clarity when adding overlays, avoiding labels being obscured.
  * Visual-only adjustment with no changes to controls, data handling, or performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->