### PR TITLE
feat: [C123] Open specific chart from closed chart card on mobile

### DIFF
--- a/src/components/ChartCard/ChartCard.tsx
+++ b/src/components/ChartCard/ChartCard.tsx
@@ -99,8 +99,10 @@ export default function ChartCard({
   return (
     <Card
       onClick={(event) => {
-        onClick?.(event)
-        setPendingScrollAfterOpen(true)
+        if (onClick) {
+          onClick(event)
+          setPendingScrollAfterOpen(true)
+        }
       }}
       className={styles['chart-card']}
     >

--- a/src/components/ChartCard/ChartCard.tsx
+++ b/src/components/ChartCard/ChartCard.tsx
@@ -1,4 +1,4 @@
-import React, { lazy, MouseEventHandler, Suspense, useState } from 'react'
+import React, { lazy, MouseEventHandler, Suspense, useEffect, useRef, useState } from 'react'
 import { Card, Typography } from '@mui/material'
 import styles from './ChartCard.module.scss'
 import { useTranslation } from 'react-i18next'
@@ -32,7 +32,26 @@ export default function ChartCard({
   chartConfigData,
 }: ChartCardProps) {
   const { t } = useTranslation()
+  const chartRef = useRef<HTMLDivElement>(null)
   const [loading] = useState(false)
+  const [pendingScrollAfterOpen, setPendingScrollAfterOpen] = useState(false)
+
+  useEffect(() => {
+    let animationFrameId: number | null = null
+
+    if (open && pendingScrollAfterOpen) {
+      animationFrameId = window.requestAnimationFrame(() => {
+        chartRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+        setPendingScrollAfterOpen(false)
+      })
+    }
+
+    return () => {
+      if (animationFrameId !== null) {
+        window.cancelAnimationFrame(animationFrameId)
+      }
+    }
+  }, [open, pendingScrollAfterOpen])
 
   const renderChartContent = () => {
     if (loading) {
@@ -77,8 +96,14 @@ export default function ChartCard({
   }
 
   return (
-    <Card {...(onClick ? { onClick: onClick } : {})} className={styles['chart-card']}>
-      <div className={getCardHeaderClassNames(open, chartConfigData)}>
+    <Card
+      onClick={(event) => {
+        onClick?.(event)
+        setPendingScrollAfterOpen(true)
+      }}
+      className={styles['chart-card']}
+    >
+      <div className={getCardHeaderClassNames(open, chartConfigData)} ref={chartRef}>
         <Typography className={styles['chart-card__region-label']}>
           {t(`regions.${regionType}`)}
         </Typography>


### PR DESCRIPTION
## Every PR

Before merging, the developer of this pull request has checked the following:

- [x] Changes have been tested locally without errors
- [x] Lint has run and any errors have been resolved
- [x] Prettier has run on any changed files
- [x] Storybook stories have run and any errors have been resolved
- [x] Pre-existing unit tests have run and passed
  - [ ] Unit tests have been added or updated, where possible, to prevent future regressions

## Post-Merge

- [ ] Code has merged and build success is confirmed in 'Actions'
- [ ] The corresponding Trello ticket has moved to the appropriate list (likely User-QA)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Chart cards now automatically scroll into view with smooth animation when expanded, improving visibility and eliminating the need for manual navigation to locate opened charts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->