### PR TITLE
fix: [C137] Fix watershed layer ordering on dynamic layer toggle

### DIFF
--- a/src/components/BaseMap/BaseMap.tsx
+++ b/src/components/BaseMap/BaseMap.tsx
@@ -425,15 +425,14 @@ export default function BaseMap({
                     type="raster"
                     key={`${layer.layerId}-${index}`}
                     source={layer.sourceId}
-                    beforeId="watershed"
+                    beforeId="sed_dispersal"
                   />
                 </Source>
               )
             )
           } else if (layer.dataType === 'rastertiles') {
             return (
-              isMapLoaded &&
-              layer.isLayerOn && (
+              isMapLoaded && (
                 <Source
                   id={layer.sourceId}
                   key={`${layer.sourceId}-${index}`}
@@ -449,6 +448,7 @@ export default function BaseMap({
                     key={`${layer.layerId}-${index}`}
                     source={layer.sourceId}
                     beforeId="watershed"
+                    layout={{ visibility: layer.isLayerOn ? 'visible' : 'none' }}
                   />
                 </Source>
               )
@@ -456,8 +456,7 @@ export default function BaseMap({
           } else {
             //other should just be 'vectortiles'
             return (
-              isMapLoaded &&
-              layer.isLayerOn && (
+              isMapLoaded && (
                 <Source
                   id={layer.sourceId}
                   key={`${layer.sourceId}-${index}`}
@@ -473,6 +472,7 @@ export default function BaseMap({
                     source={layer.sourceId}
                     source-layer={layer.sourceFileName}
                     beforeId="watershed"
+                    layout={{ visibility: layer.isLayerOn ? 'visible' : 'none' }}
                     paint={{
                       // @ts-expect-error - doesn't like fill-color being a string?
                       'fill-color': benthicSubLayerFillExpression,

--- a/src/components/BaseMap/BaseMap.tsx
+++ b/src/components/BaseMap/BaseMap.tsx
@@ -96,6 +96,9 @@ function WatershedLayers({ layer, index }) {
         source={layer.sourceId}
         source-layer={layer.sourceFileName}
         beforeId="label_airport"
+        layout={{
+          visibility: layer.isLayerOn ? 'visible' : 'none',
+        }}
         paint={{
           'fill-color': transparent,
           'fill-outline-color': layer.outlineColor,
@@ -107,9 +110,10 @@ function WatershedLayers({ layer, index }) {
         key={`${layer.layerId}-lines-${index}`}
         source={layer.sourceId}
         source-layer={layer.sourceFileName}
-        beforeId="label_airport" // label_airport labels show on top
+        beforeId="label_airport"
         layout={{
-          'line-sort-key': 5, //watershed outlines should overlay all other layers
+          visibility: layer.isLayerOn ? 'visible' : 'none',
+          'line-sort-key': 5,
         }}
         paint={{
           'line-width': [
@@ -148,7 +152,10 @@ function PmTileLayers({ layer, index }) {
         key={`${layer.layerId}-${index}`}
         source={layer.sourceId}
         source-layer={layer.sourceFileName}
-        beforeId="label_airport"
+        beforeId="watershed"
+        layout={{
+          visibility: layer.isLayerOn ? 'visible' : 'none',
+        }}
         paint={{
           'line-color': layer.outlineColor,
           'line-dasharray': layer.outlineStyle ? [0, 2, 5] : [2, 0],
@@ -281,15 +288,24 @@ export default function BaseMap({
       return
     }
 
-    map.on('error', (e) => handleError(e, setLayerErrors))
-    map.on('sourcedata', (e) => handleSourceData(e, setLayerErrors))
+    const onError = (e) => handleError(e, setLayerErrors)
+    const onSourceData = (e) => handleSourceData(e, setLayerErrors)
+
+    map.on('error', onError)
+    map.on('sourcedata', onSourceData)
 
     // eslint-disable-next-line consistent-return
     return () => {
-      map.off('error', (e) => handleError(e, setLayerErrors))
-      map.off('sourcedata', (e) => handleSourceData(e, setLayerErrors))
+      map.off('error', onError)
+      map.off('sourcedata', onSourceData)
     }
   }, [isMapLoaded])
+
+  const watershedIndex = useMemo(
+    () => mapLayers.findIndex((l) => l.layerId === 'watershed'),
+    [mapLayers],
+  )
+  const watershedLayer = watershedIndex >= 0 ? mapLayers[watershedIndex] : undefined
 
   const benthicFillColors = useMapStore((s) => s.benthicMapSubLayerColors)
   const benthicSubLayerFillExpression = useMemo(
@@ -317,14 +333,6 @@ export default function BaseMap({
       useMapStore.getState().setMapRef(mapRef.current)
     }
   }, [isMapLoaded])
-
-  useEffect(() => {
-    if (mapRef.current && isMapLoaded) {
-      const map = mapRef.current.getMap()
-      map.moveLayer('plumes', 'label_airport')
-      map.moveLayer('watershed', 'label_airport')
-    }
-  }, [isMapLoaded, mapLayers])
 
   const handleMapLoad = () => {
     setIsMapLoaded(true)
@@ -388,15 +396,20 @@ export default function BaseMap({
             <NavigationControl position="bottom-right" showCompass={false} />
           </>
         )}
+        {/* Watershed always rendered first so other layers can reference it via beforeId */}
+        {isMapLoaded && watershedLayer && (
+          <WatershedLayers
+            key={`layer-${watershedIndex}`}
+            layer={watershedLayer}
+            index={watershedIndex}
+          />
+        )}
         {mapLayers.map((layer, index) => {
-          if (layer.dataType === 'pmtiles' && layer.layerId !== 'watershed') {
+          if (layer.layerId === 'watershed') {
+            return null // rendered above, always present
+          } else if (layer.dataType === 'pmtiles') {
             return (
-              isMapLoaded &&
-              layer.isLayerOn && <PmTileLayers key={`layer-${index}`} layer={layer} index={index} />
-            )
-          } else if (layer.layerId === 'watershed' && layer.isLayerOn) {
-            return (
-              isMapLoaded && <WatershedLayers key={`layer-${index}`} layer={layer} index={index} />
+              isMapLoaded && <PmTileLayers key={`layer-${index}`} layer={layer} index={index} />
             )
           } else if (
             layer.dataType === 'rastertiles' &&
@@ -420,7 +433,7 @@ export default function BaseMap({
                     type="raster"
                     key={`${layer.layerId}-${index}`}
                     source={layer.sourceId}
-                    beforeId="label_airport"
+                    beforeId="watershed"
                   />
                 </Source>
               )
@@ -447,7 +460,7 @@ export default function BaseMap({
                     type="raster"
                     key={`${layer.layerId}-${index}`}
                     source={layer.sourceId}
-                    // beforeId="label_airport"
+                    beforeId="watershed"
                   />
                 </Source>
               )
@@ -471,7 +484,7 @@ export default function BaseMap({
                     key={`${layer.layerId}-${index}`}
                     source={layer.sourceId}
                     source-layer={layer.sourceFileName}
-                    beforeId="label_airport"
+                    beforeId="watershed"
                     paint={{
                       // @ts-expect-error - doesn't like fill-color being a string?
                       'fill-color': benthicSubLayerFillExpression,

--- a/src/data/mapData.ts
+++ b/src/data/mapData.ts
@@ -65,7 +65,6 @@ export const reefExtentSubLayer: LayerInfo = {
 }
 
 export const layers: LayerInfo[] = [
-  reefExtentSubLayer,
   {
     dataType: 'rastertiles',
     isLayerOn: true,
@@ -79,6 +78,7 @@ export const layers: LayerInfo[] = [
     title: 'map_layers.sediment_dispersal',
     year: 2000, //temp - data only available for Solomon Islands
   },
+  reefExtentSubLayer,
   {
     dataType: 'cog',
     isLayerOn: false,


### PR DESCRIPTION
**Summary:**
- Fix watershed layer ordering on dynamic layer toggle. Previously, toggling a layer like land use/land cover re-added it above watershed boundaries, hiding them and their hover/select highlights. The existing `moveLayer` ran too late - react-map-gl manages layer positions during render, before the imperative `moveLayer` call. Instead it was replaced with declarative `beforeId` chaining. Watershed renders first with `beforeId="label_airport"`, and other layers reference either `"watershed"` or a lower always-rendered anchor to maintain their position in the stack.
- Always render boundary layers (watershed, regions, countries, plumes) with `layout.visibility` instead of adding/removing them. These layers have no toggle in the UI, so conditional rendering was unnecessary and may have resulted in tile re-fetching.
- Enforce ordering for sed_dispersal, reef_extent, and benthic. These are now always rendered with `layout.visibility` so their stack position is stable across toggles. Array order in `mapData.ts` controls mount order to guarantee the required back-to-front ordering: sed_dispersal → reef_extent → benthic. Conditionally-rendered COG layers (land use/land cover, sed_export) use `beforeId="sed_dispersal"` to always insert below the trio. When `visibility` is `'none'`, maplibre does not request tiles for sources with no visible layers ([mapbox/mapbox-gl-js#7457](https://github.com/mapbox/mapbox-gl-js/issues/7457)), so there is no bandwidth cost for hidden layers.
- Fix event handler leak in error/sourcedata listeners where `map.off()` received different arrow function references than `map.on()`.

## Every PR

Before merging, the developer of this pull request has checked the following:

- [x] Changes have been tested locally without errors
- [x] Lint has run and any errors have been resolved
- [x] Prettier has run on any changed files
- [x] Storybook stories have run and any errors have been resolved
- [x] Pre-existing unit tests have run and passed
  - [ ] Unit tests have been added or updated, where possible, to prevent future regressions

## Post-Merge

- [ ] Code has merged and build success is confirmed in 'Actions'
- [ ] The corresponding Trello ticket has moved to the appropriate list (likely User-QA)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced layer visibility control for watershed and related map layers; they now correctly render based on enabled/disabled state.
  * Fixed map event handler cleanup to ensure proper removal of event listeners.

* **Refactor**
  * Streamlined map layer rendering and ordering logic for improved stability and more reliable layer positioning on the map.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->