### PR TITLE
feat: [C105] Add region URL param routing with two way sync

### DIFF
--- a/src/components/BaseMap/BaseMap.stories.ts
+++ b/src/components/BaseMap/BaseMap.stories.ts
@@ -14,7 +14,7 @@ type Story = StoryObj<typeof meta>
 export const Primary: Story = {
   args: {
     mapLayers: layers,
-    setSelectedRegion: () => {},
+    onRegionChange: () => {},
     selectedRegion: defaultGlobalRegionOption,
     setBreadcrumb: () => {},
   },
@@ -35,7 +35,7 @@ export const Primary: Story = {
 export const Loading: Story = {
   args: {
     mapLayers: layers,
-    setSelectedRegion: () => {},
+    onRegionChange: () => {},
     selectedRegion: defaultGlobalRegionOption,
     setBreadcrumb: () => {},
   },

--- a/src/components/BaseMap/BaseMap.tsx
+++ b/src/components/BaseMap/BaseMap.tsx
@@ -161,22 +161,19 @@ function PmTileLayers({ layer, index }) {
 interface BaseMapProps {
   mapLayers: LayerInfo[]
   selectedRegion: RegionOption
-  setSelectedRegion: Dispatch<SetStateAction<RegionOption>>
+  onRegionChange: (region: RegionOption) => void
   setBreadcrumb: Dispatch<SetStateAction<RegionOption[]>>
 }
 
 export default function BaseMap({
   mapLayers,
   selectedRegion,
-  setSelectedRegion,
+  onRegionChange,
   setBreadcrumb,
 }: BaseMapProps) {
   const { t } = useTranslation()
   const { isDesktopWidth } = useResponsive()
   const [isMapLoaded, setIsMapLoaded] = useState(false)
-  const defaultLng = 157.146019 //Initial location - Solomon Islands
-  const defaultLat = -7.980446
-  const defaultMapZoom = 11
   const mapRef = useRef<MapRef | null>(useMapStore.getState().mapReference)
   const [layerErrors, setLayerErrors] = useState<Record<string, string>>({})
   const polygonHoverRef = useRef<string | number | null>(null)
@@ -217,7 +214,7 @@ export default function BaseMap({
           updatedRegions.push(subRegionWithUpdatedConfig)
 
           setBreadcrumb(updatedRegions)
-          setSelectedRegion(subRegionWithUpdatedConfig)
+          onRegionChange(subRegionWithUpdatedConfig)
 
           const config = isDesktopWidth ? mapFitBoundsDesktopConfig : mapFitBoundsMobileConfig
           map.fitBounds(bounds, {
@@ -228,7 +225,7 @@ export default function BaseMap({
         }
       }
     },
-    [isDesktopWidth, selectedRegion, setBreadcrumb, setSelectedFeature, setSelectedRegion],
+    [isDesktopWidth, selectedRegion, setBreadcrumb, setSelectedFeature, onRegionChange],
   )
 
   const polygonHoverHandler = useMemo(() => createPolygonHoverHandler(polygonHoverRef), [])
@@ -376,9 +373,9 @@ export default function BaseMap({
         ref={mapRef}
         style={{ width: '100%', height: '100%' }}
         initialViewState={{
-          longitude: defaultLng,
-          latitude: defaultLat,
-          zoom: defaultMapZoom,
+          longitude: selectedRegion.centerCoord.lng,
+          latitude: selectedRegion.centerCoord.lat,
+          zoom: selectedRegion.zoomLevel,
         }}
         mapStyle={`https://api.maptiler.com/maps/basic/style.json?key=${apiKey}`}
         onLoad={() => handleMapLoad()}

--- a/src/components/BaseMap/BaseMap.tsx
+++ b/src/components/BaseMap/BaseMap.tsx
@@ -43,7 +43,7 @@ import { useSelectedFeatureStore } from '../../stores/selectedFeatureStore'
 import { LayerInfo } from '../../types/MapDataTypes'
 import { useMapStore } from '../../stores/mapStore'
 import { transparent } from '../../data/mapData'
-import { regionOptions } from '../../data/regionData'
+import { defaultGlobalRegionOption, regionOptions } from '../../data/regionData'
 
 const getRegionByLabel = (regionLabel) => regionOptions.find((opt) => opt.label === regionLabel)
 
@@ -214,14 +214,16 @@ export default function BaseMap({
             zoomLevel: map.getZoom(),
             grouping: 3,
           }
-          const updatedRegions: RegionOption[] = [selectedRegion]
+          const updatedRegions: RegionOption[] = [defaultGlobalRegionOption]
           if (addtlRegion) {
             updatedRegions.push(addtlRegion)
           }
           updatedRegions.push(subRegionWithUpdatedConfig)
 
           setBreadcrumb(updatedRegions)
-          onRegionChange(subRegionWithUpdatedConfig)
+          if (addtlRegion) {
+            onRegionChange(addtlRegion)
+          }
 
           const config = isDesktopWidth ? mapFitBoundsDesktopConfig : mapFitBoundsMobileConfig
           map.fitBounds(bounds, {
@@ -232,7 +234,7 @@ export default function BaseMap({
         }
       }
     },
-    [isDesktopWidth, selectedRegion, setBreadcrumb, setSelectedFeature, onRegionChange],
+    [isDesktopWidth, setBreadcrumb, setSelectedFeature, onRegionChange],
   )
 
   const polygonHoverHandler = useMemo(() => createPolygonHoverHandler(polygonHoverRef), [])

--- a/src/components/MapContainer/MapContainer.tsx
+++ b/src/components/MapContainer/MapContainer.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 import { useSearchParams } from 'react-router'
 import LayersDrawer from '../LayersDrawer/LayersDrawer'
 import BaseMap from '../BaseMap/BaseMap'
@@ -8,9 +8,8 @@ import TrendsDrawer from '../TrendsDrawer/TrendsDrawer'
 import YearSelect from '../YearSelect/YearSelect'
 import { layers } from '../../data/mapData'
 import { RegionOption } from '../../types/RegionDataTypes'
-import { defaultGlobalRegionOption } from '../../data/regionData'
 import { LayerInfo } from '../../types/MapDataTypes'
-import { getValidYear } from '../../utils/routeUtils'
+import { getValidRegion, getValidYear } from '../../utils/routeUtils'
 
 export default function MapContainer() {
   const [searchParams, setSearchParams] = useSearchParams()
@@ -19,19 +18,42 @@ export default function MapContainer() {
   const normalizedYearParam = selectedYear.toString()
   const shouldSyncYearParam = year !== normalizedYearParam
 
+  const regionParam = searchParams.get('region')
+  const initialRegion = getValidRegion(regionParam)
+  const normalizedRegionParam = initialRegion.id
+  const shouldSyncRegionParam = regionParam !== normalizedRegionParam
+  const [selectedRegion, setSelectedRegion] = useState<RegionOption>(initialRegion)
+
   const [mapLayers, setMapLayers] = useState<LayerInfo[]>(layers)
-  const [selectedRegion, setSelectedRegion] = useState<RegionOption>(defaultGlobalRegionOption)
   const [breadcrumb, setBreadcrumb] = useState<RegionOption[]>([selectedRegion])
 
   useEffect(() => {
-    if (!shouldSyncYearParam) {
+    if (!shouldSyncYearParam && !shouldSyncRegionParam) {
       return
     }
 
     const nextSearchParams = new URLSearchParams(searchParams)
     nextSearchParams.set('year', normalizedYearParam)
+    nextSearchParams.set('region', normalizedRegionParam)
     setSearchParams(nextSearchParams, { replace: true })
-  }, [normalizedYearParam, searchParams, setSearchParams, shouldSyncYearParam])
+  }, [
+    normalizedYearParam,
+    normalizedRegionParam,
+    searchParams,
+    setSearchParams,
+    shouldSyncYearParam,
+    shouldSyncRegionParam,
+  ])
+
+  const handleRegionChange = useCallback(
+    (region: RegionOption) => {
+      setSelectedRegion(region)
+      const nextSearchParams = new URLSearchParams(searchParams)
+      nextSearchParams.set('region', region.id)
+      setSearchParams(nextSearchParams)
+    },
+    [searchParams, setSearchParams],
+  )
 
   const handleYearChange = (year: number) => {
     const nextSearchParams = new URLSearchParams(searchParams)
@@ -49,7 +71,7 @@ export default function MapContainer() {
         />
         <RegionSelect
           selectedRegion={selectedRegion}
-          setSelectedRegion={setSelectedRegion}
+          onRegionChange={handleRegionChange}
           breadcrumb={breadcrumb}
           setBreadcrumb={setBreadcrumb}
         />
@@ -59,7 +81,7 @@ export default function MapContainer() {
       <BaseMap
         mapLayers={mapLayers}
         selectedRegion={selectedRegion}
-        setSelectedRegion={setSelectedRegion}
+        onRegionChange={handleRegionChange}
         setBreadcrumb={setBreadcrumb}
       />
     </div>

--- a/src/components/MapContainer/MapContainer.tsx
+++ b/src/components/MapContainer/MapContainer.tsx
@@ -10,6 +10,7 @@ import { layers } from '../../data/mapData'
 import { RegionOption } from '../../types/RegionDataTypes'
 import { LayerInfo } from '../../types/MapDataTypes'
 import { getValidRegion, getValidYear } from '../../utils/routeUtils'
+import { defaultGlobalRegionOption } from '../../data/regionData'
 
 export default function MapContainer() {
   const [searchParams, setSearchParams] = useSearchParams()
@@ -25,7 +26,9 @@ export default function MapContainer() {
   const [selectedRegion, setSelectedRegion] = useState<RegionOption>(initialRegion)
 
   const [mapLayers, setMapLayers] = useState<LayerInfo[]>(layers)
-  const [breadcrumb, setBreadcrumb] = useState<RegionOption[]>([selectedRegion])
+  const [breadcrumb, setBreadcrumb] = useState<RegionOption[]>(
+    initialRegion.grouping > 0 ? [defaultGlobalRegionOption, initialRegion] : [initialRegion],
+  )
 
   useEffect(() => {
     if (!shouldSyncYearParam && !shouldSyncRegionParam) {
@@ -44,6 +47,13 @@ export default function MapContainer() {
     shouldSyncYearParam,
     shouldSyncRegionParam,
   ])
+
+  useEffect(() => {
+    setSelectedRegion(initialRegion)
+    setBreadcrumb(
+      initialRegion.grouping > 0 ? [defaultGlobalRegionOption, initialRegion] : [initialRegion],
+    )
+  }, [initialRegion])
 
   const handleRegionChange = useCallback(
     (region: RegionOption) => {

--- a/src/components/RegionSelect/RegionSelect.stories.tsx
+++ b/src/components/RegionSelect/RegionSelect.stories.tsx
@@ -17,7 +17,7 @@ export const ShortBreadcrumb: Story = {
     breadcrumb: [defaultGlobalRegionOption],
     setBreadcrumb: () => {},
     selectedRegion: defaultGlobalRegionOption,
-    setSelectedRegion: () => {},
+    onRegionChange: () => {},
   },
   decorators: [(Story) => <Story />],
   play: async ({ canvas }) => {
@@ -32,7 +32,7 @@ export const LongBreadcrumb: Story = {
     breadcrumb: [defaultGlobalRegionOption, regionOptions[1], regionOptions[4]],
     setBreadcrumb: () => {},
     selectedRegion: defaultGlobalRegionOption,
-    setSelectedRegion: () => {},
+    onRegionChange: () => {},
   },
   play: async ({ canvas }) => {
     const input = canvas.getByRole('combobox')

--- a/src/components/RegionSelect/RegionSelect.tsx
+++ b/src/components/RegionSelect/RegionSelect.tsx
@@ -15,14 +15,14 @@ interface RegionSelectProps {
   breadcrumb: RegionOption[]
   setBreadcrumb: Dispatch<SetStateAction<RegionOption[]>>
   selectedRegion: RegionOption
-  setSelectedRegion: Dispatch<SetStateAction<RegionOption>>
+  onRegionChange: (region: RegionOption) => void
 }
 
 export default function RegionSelect({
   breadcrumb,
   setBreadcrumb,
   selectedRegion,
-  setSelectedRegion,
+  onRegionChange,
 }: RegionSelectProps) {
   const { t } = useTranslation()
   const mapRef = useMapStore((s) => s.mapReference)
@@ -87,7 +87,7 @@ export default function RegionSelect({
       jumpToRegion(region)
     }
     if (selectedRegion !== region) {
-      setSelectedRegion(region)
+      onRegionChange(region)
       prepBreadcrumb(region)
     }
   }

--- a/src/utils/routeUtils.ts
+++ b/src/utils/routeUtils.ts
@@ -1,4 +1,15 @@
 import { availableYears, defaultYear } from '../data/mapData'
+import { defaultGlobalRegionOption, regionOptions } from '../data/regionData'
+import { RegionOption } from '../types/RegionDataTypes'
+
+export function getValidRegion(regionFromSearchParam: string | null): RegionOption {
+  if (!regionFromSearchParam) {
+    return defaultGlobalRegionOption
+  }
+  const found = regionOptions.find((option) => option.id === regionFromSearchParam)
+
+  return found ?? defaultGlobalRegionOption
+}
 
 export function getValidYear(yearFromSearchParam: string | null) {
   const parsedYear = Number(yearFromSearchParam)


### PR DESCRIPTION
Region selection updates the URL and navigating to a URL with a region param updates the UI to reflect that selection

## Every PR

Before merging, the developer of this pull request has checked the following:

- [x] Changes have been tested locally without errors
- [x] Lint has run and any errors have been resolved
- [x] Prettier has run on any changed files
- [x] Storybook stories have run and any errors have been resolved
- [x] Pre-existing unit tests have run and passed
  - [x] Unit tests have been added or updated, where possible, to prevent future regressions

## Post-Merge

- [ ] Code has merged and build success is confirmed in 'Actions'
- [ ] The corresponding Trello ticket has moved to the appropriate list (likely User-QA)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Region selections are now synchronized with URL parameters, allowing users to share and bookmark specific regional views.
  * Map view dynamically initializes based on the selected region's coordinates and zoom level instead of hardcoded defaults.

* **Improvements**
  * Enhanced region validation to ensure selections are properly normalized against available options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->