### PR TITLE
fix: [C145] Maintain the correct year-based map layer from changing year and layer toggling state.

### DIFF
--- a/src/components/LayerToggleCard/LayerToggleCard.tsx
+++ b/src/components/LayerToggleCard/LayerToggleCard.tsx
@@ -28,6 +28,7 @@ interface LayerToggleCardProps {
 const getLayerToggleDetails = (
   layer: LayerInfo,
   toggleSubLayer: (event: React.ChangeEvent<HTMLInputElement>) => void,
+  selectedYear: number,
   mapSubLayers?: SubLayerInfo[],
 ) => {
   const layerId: string = layer.layerId
@@ -45,7 +46,7 @@ const getLayerToggleDetails = (
       toggleCardDetails = layer.isLayerOn && (
         <>
           <GradientLegend variation={layerId} title={layer.legendTitle} />
-          <RadioSelect />
+          <RadioSelect selectedYear={selectedYear} />
         </>
       )
       break
@@ -61,13 +62,13 @@ const getLayerToggleDetails = (
 }
 
 //if not country or region, disable watershed option
-const RadioSelect = () => {
+const RadioSelect = ({ selectedYear }: { selectedYear: number }) => {
   const [selectedValue, setSelectedValue] = useState<'pixel' | 'watershed'>('pixel')
   const toggleSedExportSubLayerFills = useMapStore((state) => state.toggleSedExportSubLayerFills)
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const toggledOnItem = event.target.value as 'pixel' | 'watershed'
-    toggleSedExportSubLayerFills(toggledOnItem)
+    toggleSedExportSubLayerFills(toggledOnItem, selectedYear)
     setSelectedValue(toggledOnItem)
   }
 
@@ -134,7 +135,7 @@ export default function LayerToggleCard({
           </>
         )}
       </div>
-      {getLayerToggleDetails(layer, toggleSubLayer, mapSubLayers)}
+      {getLayerToggleDetails(layer, toggleSubLayer, selectedYear, mapSubLayers)}
     </Card>
   )
 }

--- a/src/components/MapContainer/MapContainer.tsx
+++ b/src/components/MapContainer/MapContainer.tsx
@@ -11,6 +11,8 @@ import { RegionOption } from '../../types/RegionDataTypes'
 import { defaultGlobalRegionOption } from '../../data/regionData'
 import { LayerInfo } from '../../types/MapDataTypes'
 import { getValidYear } from '../../utils/routeUtils'
+import { mapToggleChange } from '../../utils/mapUtils'
+import { useMapStore } from '../../stores/mapStore'
 
 export default function MapContainer() {
   const [searchParams, setSearchParams] = useSearchParams()
@@ -18,6 +20,8 @@ export default function MapContainer() {
   const selectedYear = getValidYear(year)
   const normalizedYearParam = selectedYear.toString()
   const shouldSyncYearParam = year !== normalizedYearParam
+
+  const toggleSedExportSubLayerFills = useMapStore((state) => state.toggleSedExportSubLayerFills)
 
   const [mapLayers, setMapLayers] = useState<LayerInfo[]>(layers)
   const [selectedRegion, setSelectedRegion] = useState<RegionOption>(defaultGlobalRegionOption)
@@ -33,9 +37,25 @@ export default function MapContainer() {
     setSearchParams(nextSearchParams, { replace: true })
   }, [normalizedYearParam, searchParams, setSearchParams, shouldSyncYearParam])
 
-  const handleYearChange = (year: number) => {
+  const handleYearChange = (nextYear: number) => {
     const nextSearchParams = new URLSearchParams(searchParams)
-    nextSearchParams.set('year', year.toString())
+
+    setMapLayers((prevMapLayers) => {
+      const yearBasedLayerIds = ['sed_export', 'lulc', 'sed_dispersal']
+
+      return yearBasedLayerIds.reduce((acc, layerId) => {
+        const prevIsLayerOn =
+          acc.find((layer) => layer.layerId === layerId && layer.year === selectedYear)
+            ?.isLayerOn ?? false
+
+        const updated = mapToggleChange(acc, layerId, false, selectedYear)
+        return mapToggleChange(updated, layerId, prevIsLayerOn, nextYear)
+      }, prevMapLayers)
+    })
+
+    toggleSedExportSubLayerFills('pixel', nextYear)
+
+    nextSearchParams.set('year', nextYear.toString())
     setSearchParams(nextSearchParams)
   }
 

--- a/src/stores/mapStore.ts
+++ b/src/stores/mapStore.ts
@@ -13,7 +13,10 @@ type MapActions = {
   setSedExportMapSubLayerColors: (colors: Record<string, string>) => void
   setBenthicMapSubLayerColors: (colors: Record<string, string>) => void
   toggleSubLayerFillColor: (toggledProperty: string) => void
-  toggleSedExportSubLayerFills: (subLayerToggledOn: 'pixel' | 'watershed') => void
+  toggleSedExportSubLayerFills: (
+    subLayerToggledOn: 'pixel' | 'watershed',
+    selectedYear: number,
+  ) => void
 }
 
 export const useMapStore = create<MapState & MapActions>((set, get) => ({
@@ -36,14 +39,16 @@ export const useMapStore = create<MapState & MapActions>((set, get) => ({
     }
     set({ benthicMapSubLayerColors: updatedFillColors })
   },
-  toggleSedExportSubLayerFills: (subLayerToggledOn: 'pixel' | 'watershed') => {
+  toggleSedExportSubLayerFills: (
+    subLayerToggledOn: 'pixel' | 'watershed',
+    selectedYear: number,
+  ) => {
     const state = get()
     const map = state.mapReference?.getMap()
     if (!map) {
       return
     }
     const regionLevel = 'country' //TODO: pass in selected region level
-    const selectedYear = 2020
 
     const pixelLayer = map.getLayer('sed_export')
     if (!pixelLayer) {


### PR DESCRIPTION
## Every PR

Before merging, the developer of this pull request has checked the following:

- [x] Changes have been tested locally without errors
- [x] Lint has run and any errors have been resolved
- [x] Prettier has run on any changed files
- [x] Storybook stories have run and any errors have been resolved
- [x] Pre-existing unit tests have run and passed
  - [ ] Unit tests have been added or updated, where possible, to prevent future regressions

## Post-Merge

- [ ] Code has merged and build success is confirmed in 'Actions'
- [ ] The corresponding Trello ticket has moved to the appropriate list (likely User-QA)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed layer synchronization when changing years. The sediment export sublayer fill toggling (pixel/watershed) now correctly maintains its state across different years, ensuring consistent visualization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->