### PR TITLE
fix: [C153] Correct plumes layer sourceFileName to match PMTiles vector layer id

### DIFF
--- a/src/data/mapData.ts
+++ b/src/data/mapData.ts
@@ -246,7 +246,7 @@ export const layers: LayerInfo[] = [
     outlineColor: plumeOutlineColor,
     parentLayerType: 'boundaries',
     sourceId: 'visual_solomons_plumeshape_2000_src',
-    sourceFileName: 'tmp4jghia4g',
+    sourceFileName: 'data',
     title: 'map_layers.dispersal_plume',
   },
   {


### PR DESCRIPTION
## Every PR

Before merging, the developer of this pull request has checked the following:

- [x] Changes have been tested locally without errors
- [x] Lint has run and any errors have been resolved
- [x] Prettier has run on any changed files
- [x] Storybook stories have run and any errors have been resolved
- [x] Pre-existing unit tests have run and passed
  - [x] Unit tests have been added or updated, where possible, to prevent future regressions

## Post-Merge

- [ ] Code has merged and build success is confirmed in 'Actions'
- [ ] The corresponding Trello ticket has moved to the appropriate list (likely User-QA)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed dispersal plume layer to reference the correct data source, ensuring accurate visualization and display of plume information on the map.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->