### PR TITLE
fix: [C149] Correct watershed hover and click behavior

### DIFF
--- a/src/components/BaseMap/BaseMap.tsx
+++ b/src/components/BaseMap/BaseMap.tsx
@@ -29,7 +29,11 @@ import { cogProtocol } from '@geomatico/maplibre-cog-protocol'
 import useResponsive from '../../hooks/useResponsive'
 import LoadingState from '../LoadingState/LoadingState'
 import { RegionOption } from '../../types/RegionDataTypes'
-import { createPolygonClickHandler, createPolygonHoverHandler } from '../../utils/mapUtils'
+import {
+  clearPolygonHover,
+  createPolygonClickHandler,
+  createPolygonHoverHandler,
+} from '../../utils/mapUtils'
 import { SourceDataEvent } from '../../types/MapLayerErrorTypes'
 import { Snackbar } from '@mui/material'
 import { useTranslation } from 'react-i18next'
@@ -368,6 +372,7 @@ export default function BaseMap({
     })
     map.on('mouseleave', 'watershed', () => {
       map.getCanvas().style.cursor = ''
+      clearPolygonHover(map, polygonHoverRef, watershedLayer)
     })
   }
 

--- a/src/utils/mapUtils.ts
+++ b/src/utils/mapUtils.ts
@@ -30,6 +30,24 @@ export function calculateFeatureBounds(feature: MapGeoJSONFeature): LngLatBounds
   return bounds
 }
 
+export function clearPolygonHover(
+  map: Map,
+  hoveredRef: RefObject<string | number | null>,
+  mapDataLayer: LayerInfo,
+) {
+  if (hoveredRef.current) {
+    map.setFeatureState(
+      {
+        source: mapDataLayer.sourceId,
+        sourceLayer: mapDataLayer.sourceFileName,
+        id: hoveredRef.current,
+      },
+      { hover: false },
+    )
+    hoveredRef.current = null
+  }
+}
+
 export function createPolygonHoverHandler(hoveredRef: RefObject<string | number | null>) {
   return (map: Map, e: MapLayerMouseEvent, mapDataLayer: LayerInfo) => {
     if (!e.features || e.features.length === 0 || !e.features[0].id) {
@@ -49,17 +67,7 @@ export function createPolygonHoverHandler(hoveredRef: RefObject<string | number 
       return
     }
 
-    if (hoveredRef.current) {
-      map.setFeatureState(
-        {
-          source: mapDataLayer.sourceId,
-          sourceLayer: mapDataLayer.sourceFileName,
-          id: hoveredRef.current,
-        },
-        { hover: false },
-      )
-      hoveredRef.current = null
-    }
+    clearPolygonHover(map, hoveredRef, mapDataLayer)
 
     // set hover on new feature
     hoveredRef.current = featureId
@@ -90,6 +98,16 @@ export function createPolygonClickHandler(
       return
     }
 
+    // Clicking an already-selected watershed recenters the map on it
+    if (polygonClickedRef.current === featureId) {
+      if (onSelect) {
+        const bounds = calculateFeatureBounds(feature)
+        onSelect(feature, bounds)
+      }
+      return
+    }
+
+    // Deselect previously selected watershed
     if (polygonClickedRef.current) {
       map.setFeatureState(
         {
@@ -99,13 +117,6 @@ export function createPolygonClickHandler(
         },
         { select: false },
       )
-      if (polygonClickedRef.current === featureId) {
-        polygonClickedRef.current = null
-        if (onSelect) {
-          onSelect(null)
-        }
-        return
-      }
     }
 
     polygonClickedRef.current = featureId

--- a/src/utils/mapUtils.ts
+++ b/src/utils/mapUtils.ts
@@ -107,7 +107,7 @@ export function createPolygonClickHandler(
       return
     }
 
-    // Deselect previously selected watershed
+    // Deselect the previously selected watershed (user clicked a different one)
     if (polygonClickedRef.current) {
       map.setFeatureState(
         {


### PR DESCRIPTION
Clear hover state on mouseleave so green outline only shows while cursor is over a watershed.
Recenter map instead of deselecting when clicking an already-selected watershed.
Extract clearPolygonHover utility to share logic between mouseleave and mousemove handlers.

## Every PR

Before merging, the developer of this pull request has checked the following:

- [x] Changes have been tested locally without errors
- [x] Lint has run and any errors have been resolved
- [x] Prettier has run on any changed files
- [x] Storybook stories have run and any errors have been resolved
- [x] Pre-existing unit tests have run and passed
  - [x] Unit tests have been added or updated, where possible, to prevent future regressions

## Post-Merge

- [ ] Code has merged and build success is confirmed in 'Actions'
- [ ] The corresponding Trello ticket has moved to the appropriate list (likely User-QA)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Polygon hover highlights now properly clear when moving the cursor away from map layers, improving visual clarity
  * Enhanced hover state management for better user feedback

* **Feature Updates**
  * Clicking an already-selected polygon now re-invokes the selection handler instead of deselecting it, providing more intuitive behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->