### PR TITLE
fix: [C150 extra] all boundary legends should stay in one card

### DIFF
--- a/src/components/LayerToggleCard/LayerToggleCard.module.scss
+++ b/src/components/LayerToggleCard/LayerToggleCard.module.scss
@@ -29,8 +29,3 @@
   justify-content: space-between;
   align-items: center;
 }
-
-.map-layer-key {
-  width: 20px;
-  height: 15px;
-}

--- a/src/components/LayerToggleCard/LayerToggleCard.tsx
+++ b/src/components/LayerToggleCard/LayerToggleCard.tsx
@@ -128,19 +128,12 @@ export default function LayerToggleCard({
           <>
             <Typography className={styles['layer-card_title']}>{t(layer.title)}</Typography>
             {layer.year && <Typography>{selectedYear}</Typography>}
-            {layer.outlineColor ? (
-              <div
-                className={styles['map-layer-key']}
-                style={{ border: `3px solid ${layer.outlineColor}` }}
-              />
-            ) : (
-              <Switch
-                className={styles['MuiSwitch-root']}
-                id={layer.layerId}
-                checked={layer.isLayerOn}
-                onChange={toggleLayer}
-              />
-            )}
+            <Switch
+              className={styles['MuiSwitch-root']}
+              id={layer.layerId}
+              checked={layer.isLayerOn}
+              onChange={toggleLayer}
+            />
           </>
         )}
       </div>

--- a/src/components/LayerToggleLegend/LayerToggleLegend.module.scss
+++ b/src/components/LayerToggleLegend/LayerToggleLegend.module.scss
@@ -16,6 +16,6 @@
 
 .LayerToggleLegend__row {
   display: flex;
-  align-content: center;
+  align-items: center;
   justify-content: space-between;
 }

--- a/src/components/LayersDrawer/LayersDrawer.module.scss
+++ b/src/components/LayersDrawer/LayersDrawer.module.scss
@@ -1,18 +1,41 @@
-@use '../../styles/theme' as *;
+@use '../../styles/theme';
 
 .LayersDrawer-root {
   .layer-toggle-button {
     position: relative;
     top: 0;
     left: 0;
-    height: $mapUtilButtonHeight;
+    height: theme.$mapUtilButtonHeight;
 
-    @include mobileUpBreakPoint {
+    @include theme.mobileUpBreakPoint {
       display: none;
     }
     & svg {
-      width: $svgSizeSmall;
-      color: $textColor;
+      width: theme.$svgSizeSmall;
+      color: theme.$textColor;
     }
   }
+}
+
+.boundary-legend-card {
+  display: flex;
+  flex-direction: column;
+  gap: theme.$defaultSpacing;
+  margin: theme.$defaultSpacing;
+  padding: theme.$defaultSpacing;
+  background-color: theme.$greyWhite;
+}
+
+.boundary-legend-row {
+  display: flex;
+  align-items: center;
+}
+
+.boundary-layer-title {
+  flex-grow: 1;
+}
+
+.boundary-layer-legend {
+  width: 20px;
+  height: 15px;
 }

--- a/src/components/LayersDrawer/LayersDrawer.module.scss
+++ b/src/components/LayersDrawer/LayersDrawer.module.scss
@@ -38,4 +38,5 @@
 .boundary-layer-legend {
   width: 20px;
   height: 15px;
+  border: 3px solid var(--outline-color, transparent);
 }

--- a/src/components/LayersDrawer/LayersDrawer.tsx
+++ b/src/components/LayersDrawer/LayersDrawer.tsx
@@ -40,7 +40,7 @@ function BoundaryLegendCard({ layers }: BoundaryLegendCardProps) {
           <Typography className={styles['boundary-layer-title']}>{t(layer.title)}</Typography>
           <div
             className={styles['boundary-layer-legend']}
-            style={{ border: `3px solid ${layer.outlineColor}` }}
+            style={{ '--outline-color': layer.outlineColor } as React.CSSProperties}
           />
         </div>
       ))}

--- a/src/components/LayersDrawer/LayersDrawer.tsx
+++ b/src/components/LayersDrawer/LayersDrawer.tsx
@@ -1,13 +1,14 @@
 import { Dispatch, SetStateAction, useCallback, useMemo, useState } from 'react'
 import LayersIcon from '@mui/icons-material/Layers'
 import { useTranslation } from 'react-i18next'
+import { Card, Typography } from '@mui/material'
 import StyledSwipeableDrawer from '../StyledSwipeableDrawer/StyledSwipeableDrawer'
 import StyledIconButtonWithTooltip from '../StyledIconButtonWithTooltip/StyledIconButtonWithTooltip'
+import LayerToggleCard from '../LayerToggleCard/LayerToggleCard'
 import styles from './LayersDrawer.module.scss'
 import { benthicSubLayers, parentLayerTitles, urlControlledLayerIds } from '../../data/mapData'
 import { LayerInfo } from '../../types/MapDataTypes'
 import { useMapStore } from '../../stores/mapStore'
-import LayerToggleCard from '../LayerToggleCard/LayerToggleCard'
 import { mapToggleChange } from '../../utils/mapUtils'
 import { sortBoundaryLayers } from '../../utils/sortUtils'
 
@@ -24,6 +25,29 @@ interface LayersDrawerProps {
   onSedSubLayerChange: (subLayerValue: 'pixel' | 'watershed') => void
   subSedLayerValue: 'pixel' | 'watershed'
 }
+
+interface BoundaryLegendCardProps {
+  layers: LayerInfo[]
+}
+
+function BoundaryLegendCard({ layers }: BoundaryLegendCardProps) {
+  const { t } = useTranslation()
+
+  return (
+    <Card className={styles['boundary-legend-card']}>
+      {[...layers].sort(sortBoundaryLayers).map((layer) => (
+        <div className={styles['boundary-legend-row']} key={layer.sourceId}>
+          <Typography className={styles['boundary-layer-title']}>{t(layer.title)}</Typography>
+          <div
+            className={styles['boundary-layer-legend']}
+            style={{ border: `3px solid ${layer.outlineColor}` }}
+          />
+        </div>
+      ))}
+    </Card>
+  )
+}
+
 export default function LayersDrawer({
   mapLayers,
   setMapLayers,
@@ -35,9 +59,11 @@ export default function LayersDrawer({
 }: LayersDrawerProps) {
   const { t } = useTranslation()
   const [open, setOpen] = useState(false)
+
   const toggleDrawer = (newOpen: boolean) => () => {
     setOpen(newOpen)
   }
+
   const mapSubLayers = useMemo(
     () =>
       benthicSubLayers.map((layer) => ({
@@ -77,31 +103,45 @@ export default function LayersDrawer({
     [toggleSubLayerFillColor, onLayerToggleChange],
   )
 
-  const getLayersByParentGroup = (parentGroup, toggleLayer) => {
-    const filteredLayers = mapLayers.filter(
-      (layer) =>
-        layer.parentLayerType === parentGroup &&
-        layer.layerId !== 'reef_extent' &&
-        (!layer.year || layer.year === selectedYear),
-    )
+  const renderLayerGroup = useCallback(
+    (parentGroup: string): React.ReactNode[] => {
+      if (parentGroup === 'boundaries') {
+        const boundaryLayers = mapLayers.filter((layer) => layer.parentLayerType === 'boundaries')
+        return boundaryLayers.length > 0
+          ? [<BoundaryLegendCard key="boundary-legend" layers={boundaryLayers} />]
+          : []
+      }
 
-    if (parentGroup === 'boundaries') {
-      filteredLayers.sort(sortBoundaryLayers)
-    }
-
-    return filteredLayers.map((layer) => (
-      <LayerToggleCard
-        layer={layer}
-        toggleLayer={toggleLayer}
-        toggleSubLayer={toggleSubLayer}
-        mapSubLayers={mapSubLayers}
-        selectedYear={selectedYear}
-        subSedLayerValue={subSedLayerValue}
-        onSedSubLayerChange={onSedSubLayerChange}
-        key={`layertoggle-${layer.sourceId}`}
-      />
-    ))
-  }
+      return mapLayers
+        .filter(
+          (layer) =>
+            layer.parentLayerType === parentGroup &&
+            layer.layerId !== 'reef_extent' &&
+            (!layer.year || layer.year === selectedYear),
+        )
+        .map((layer) => (
+          <LayerToggleCard
+            key={`layertoggle-${layer.sourceId}`}
+            layer={layer}
+            toggleLayer={toggleLayer}
+            toggleSubLayer={toggleSubLayer}
+            mapSubLayers={mapSubLayers}
+            selectedYear={selectedYear}
+            subSedLayerValue={subSedLayerValue}
+            onSedSubLayerChange={onSedSubLayerChange}
+          />
+        ))
+    },
+    [
+      mapLayers,
+      selectedYear,
+      toggleLayer,
+      toggleSubLayer,
+      mapSubLayers,
+      subSedLayerValue,
+      onSedSubLayerChange,
+    ],
+  )
 
   return (
     <div className={styles['LayersDrawer-root']}>
@@ -121,16 +161,17 @@ export default function LayersDrawer({
         onOpen={toggleDrawer(true)}
       >
         {Object.entries(parentLayerTitles).map(([key, value]) => {
-          const parentGroupLayers = getLayersByParentGroup(key, toggleLayer) ?? []
-          if (parentGroupLayers.length > 0) {
-            return (
-              <div key={key}>
-                <h2 style={{ padding: '8px' }}>{t(value)}</h2>
-                {parentGroupLayers}
-              </div>
-            )
+          const layerNodes = renderLayerGroup(key)
+          if (layerNodes.length === 0) {
+            return null
           }
-          return null
+
+          return (
+            <div key={key}>
+              <h2 style={{ padding: '8px' }}>{t(value)}</h2>
+              {layerNodes}
+            </div>
+          )
         })}
       </StyledSwipeableDrawer>
     </div>


### PR DESCRIPTION
## Every PR

Before merging, the developer of this pull request has checked the following:

- [x] Changes have been tested locally without errors
- [x] Lint has run and any errors have been resolved
- [x] Prettier has run on any changed files
- [x] Storybook stories have run and any errors have been resolved
- [x] Pre-existing unit tests have run and passed
  - [ ] Unit tests have been added or updated, where possible, to prevent future regressions

## Post-Merge

- [ ] Code has merged and build success is confirmed in 'Actions'
- [ ] The corresponding Trello ticket has moved to the appropriate list (likely User-QA)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added boundary legend cards showing per-boundary-layer titles and outline previews.

* **Bug Fixes**
  * Fixed vertical alignment in layer toggle rows for proper centering.
  * Layer toggles now consistently render a switch control (removed previous conditional color-key rendering).

* **Style**
  * Updated layer drawer styling and theme usage; added classes for boundary legend layout and visuals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->