### PR TITLE
feat: [C151] Add watershed URL routing

### DIFF
--- a/src/components/BaseMap/BaseMap.stories.ts
+++ b/src/components/BaseMap/BaseMap.stories.ts
@@ -16,6 +16,9 @@ export const Primary: Story = {
     mapLayers: layers,
     sedExportSubLayerValue: 'pixel',
     onRegionChange: () => {},
+    onWatershedChange: () => {},
+    initialWatershedId: null,
+    hasExplicitViewState: false,
     selectedRegion: defaultGlobalRegionOption,
     setBreadcrumb: () => {},
     initialViewState: {
@@ -43,6 +46,9 @@ export const Loading: Story = {
   args: {
     mapLayers: layers,
     onRegionChange: () => {},
+    onWatershedChange: () => {},
+    initialWatershedId: null,
+    hasExplicitViewState: false,
     selectedRegion: defaultGlobalRegionOption,
     setBreadcrumb: () => {},
     sedExportSubLayerValue: 'pixel',

--- a/src/components/BaseMap/BaseMap.tsx
+++ b/src/components/BaseMap/BaseMap.tsx
@@ -30,9 +30,11 @@ import useResponsive from '../../hooks/useResponsive'
 import LoadingState from '../LoadingState/LoadingState'
 import { RegionOption } from '../../types/RegionDataTypes'
 import {
+  calculateFeatureBounds,
   clearPolygonHover,
   createPolygonClickHandler,
   createPolygonHoverHandler,
+  querySourceFeatureWhenReady,
 } from '../../utils/mapUtils'
 import { SourceDataEvent } from '../../types/MapLayerErrorTypes'
 import { Snackbar } from '@mui/material'
@@ -174,6 +176,9 @@ interface BaseMapProps {
   sedExportSubLayerValue: 'pixel' | 'watershed'
   selectedRegion: RegionOption
   onRegionChange: (region: RegionOption) => void
+  onWatershedChange: (id: string | null) => void
+  initialWatershedId: string | null
+  hasExplicitViewState: boolean
   setBreadcrumb: Dispatch<SetStateAction<RegionOption[]>>
   initialViewState: {
     longitude: number
@@ -188,6 +193,9 @@ export default function BaseMap({
   sedExportSubLayerValue,
   selectedRegion,
   onRegionChange,
+  onWatershedChange,
+  initialWatershedId,
+  hasExplicitViewState,
   setBreadcrumb,
   initialViewState,
   onMapMoveEnd,
@@ -210,14 +218,18 @@ export default function BaseMap({
   const setSelectedFeature = useSelectedFeatureStore((s) => s.setSelectedFeature)
 
   const handleFeatureSelect = useCallback(
-    (feature: MapGeoJSONFeature | null, bounds?: LngLatBounds) => {
+    (
+      feature: MapGeoJSONFeature | null,
+      bounds?: LngLatBounds,
+      options?: { skipFitBounds?: boolean },
+    ) => {
       setSelectedFeature(feature)
 
       if (feature && bounds) {
         const map = mapRef.current?.getMap()
 
         if (map) {
-          //todo: for plume
+          // TODO: for plume, use different property lookup
           const countryOrRegion = feature.properties.TERRITORY1 || feature.properties.REALM
 
           const addtlRegion: RegionOption | undefined = getRegionByLabel(countryOrRegion)
@@ -229,6 +241,9 @@ export default function BaseMap({
             zoomLevel: map.getZoom(),
             grouping: 3,
           }
+
+          // Breadcrumb: Global > [Country] > Watershed
+          // Country is omitted if it can't be determined from the feature
           const updatedRegions: RegionOption[] = [defaultGlobalRegionOption]
           if (addtlRegion) {
             updatedRegions.push(addtlRegion)
@@ -240,16 +255,23 @@ export default function BaseMap({
             onRegionChange(addtlRegion)
           }
 
-          const config = isDesktopWidth ? mapFitBoundsDesktopConfig : mapFitBoundsMobileConfig
-          map.fitBounds(bounds, {
-            padding: config.padding,
-            maxZoom: config.maxZoom,
-            duration: 800,
-          })
+          // Sync watershed ID to URL
+          const featureWatershedId = feature.id != null ? String(feature.id) : null
+          onWatershedChange(featureWatershedId)
+
+          // Skip fitBounds when restoring from URL with explicit lat/lng/zoom
+          if (!options?.skipFitBounds) {
+            const config = isDesktopWidth ? mapFitBoundsDesktopConfig : mapFitBoundsMobileConfig
+            map.fitBounds(bounds, {
+              padding: config.padding,
+              maxZoom: config.maxZoom,
+              duration: 800,
+            })
+          }
         }
       }
     },
-    [isDesktopWidth, setBreadcrumb, setSelectedFeature, onRegionChange],
+    [isDesktopWidth, setBreadcrumb, setSelectedFeature, onRegionChange, onWatershedChange],
   )
 
   const polygonHoverHandler = useMemo(() => createPolygonHoverHandler(polygonHoverRef), [])
@@ -326,6 +348,81 @@ export default function BaseMap({
     [mapLayers],
   )
   const watershedLayer = watershedIndex >= 0 ? mapLayers[watershedIndex] : undefined
+
+  // When selectedFeature is cleared externally (e.g., dropdown region change),
+  // remove the visual highlight from the map.
+  const selectedFeature = useSelectedFeatureStore((s) => s.selectedFeature)
+  useEffect(() => {
+    if (!selectedFeature && polygonClickRef.current && isMapLoaded) {
+      const map = mapRef.current?.getMap()
+      if (map && watershedLayer) {
+        map.setFeatureState(
+          {
+            source: watershedLayer.sourceId,
+            sourceLayer: watershedLayer.sourceFileName,
+            id: polygonClickRef.current,
+          },
+          { select: false },
+        )
+        polygonClickRef.current = null
+      }
+    }
+  }, [selectedFeature, isMapLoaded, watershedLayer])
+
+  // Watershed restoration from URL
+  useEffect(() => {
+    if (!isMapLoaded || !initialWatershedId || !watershedLayer) {
+      return undefined
+    }
+
+    const map = mapRef.current?.getMap()
+    if (!map) {
+      return undefined
+    }
+
+    // watershed_id is numeric in tile data. Parse to number to match
+    // the promoted feature ID used by MapLibre for setFeatureState.
+    const featureId = isNaN(Number(initialWatershedId))
+      ? initialWatershedId
+      : Number(initialWatershedId)
+
+    return querySourceFeatureWhenReady(
+      map,
+      watershedLayer.sourceId,
+      watershedLayer.sourceFileName,
+      ['==', ['get', 'watershed_id'], Number(initialWatershedId)],
+      (feature) => {
+        if (!feature) {
+          onWatershedChange(null)
+          return
+        }
+
+        // querySourceFeatures doesn't set 'source' on returned features
+        // (unlike click events). Charts need it to identify the data source.
+        if (!feature.source) {
+          feature.source = watershedLayer.sourceId
+        }
+
+        polygonClickRef.current = featureId
+        map.setFeatureState(
+          {
+            source: watershedLayer.sourceId,
+            sourceLayer: watershedLayer.sourceFileName,
+            id: featureId,
+          },
+          { select: true },
+        )
+
+        const bounds = calculateFeatureBounds(feature)
+        handleFeatureSelect(feature, bounds, {
+          skipFitBounds: hasExplicitViewState,
+        })
+      },
+    )
+    // handleFeatureSelect and onWatershedChange intentionally omitted
+    // initialWatershedId is stable (captured once at mount) so this effect only runs once when the map loads.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isMapLoaded, initialWatershedId, watershedLayer, hasExplicitViewState])
 
   const benthicFillColors = useMapStore((s) => s.benthicMapSubLayerColors)
   const benthicSubLayerFillExpression = useMemo(

--- a/src/components/MapContainer/MapContainer.tsx
+++ b/src/components/MapContainer/MapContainer.tsx
@@ -14,9 +14,11 @@ import {
   getValidLayers,
   getValidYear,
   getValidRegion,
+  getValidWatershed,
   getValidZoom,
 } from '../../utils/routeUtils'
 import { useMapStore } from '../../stores/mapStore'
+import { useSelectedFeatureStore } from '../../stores/selectedFeatureStore'
 import { defaultGlobalRegionOption } from '../../data/regionData'
 
 export default function MapContainer() {
@@ -36,8 +38,16 @@ export default function MapContainer() {
   const normalizedLayersParam = selectedLayers.length > 0 ? selectedLayers.join(',') : 'none'
   const shouldSyncLayersParam = layersParam !== normalizedLayersParam
 
+  // Captured once at mount — only used for initial restoration on page load.
+  // Clicks update the URL via handleWatershedChange but don't re-trigger restoration.
+  const [initialWatershedId] = useState(() => getValidWatershed(searchParams.get('watershed')))
+
+  // TODO: Handle dispersal-point URL param (C152)
+
   const { lat, lng } = getValidLatLng(searchParams.get('lat'), searchParams.get('lng'))
   const zoom = getValidZoom(searchParams.get('zoom'))
+
+  const hasExplicitViewState = lat !== null && lng !== null && zoom !== null
 
   const [mapLayers, setMapLayers] = useState<LayerInfo[]>(layers)
   const [subSedLayerValue, setSubLayerValue] = useState<'pixel' | 'watershed'>('pixel')
@@ -49,6 +59,7 @@ export default function MapContainer() {
 
   const toggleSedExportSubLayerFills = useMapStore((state) => state.toggleSedExportSubLayerFills)
   const turnOffSedExportSubLayerFills = useMapStore((state) => state.turnOffSedExportSubLayerFills)
+  const clearSelectedFeature = useSelectedFeatureStore((s) => s.clearSelectedFeature)
   const latestSearchParamsRef = useRef(new URLSearchParams(searchParams))
 
   useEffect(() => {
@@ -124,6 +135,37 @@ export default function MapContainer() {
       })
     },
     [updateSearchParams],
+  )
+
+  // Updates or removes the watershed URL param. Always replaces (no new
+  // history entry) because the region change already pushes one on click.
+  const handleWatershedChange = useCallback(
+    (newWatershedId: string | null) => {
+      updateSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev)
+          if (newWatershedId) {
+            next.set('watershed', newWatershedId)
+          } else {
+            next.delete('watershed')
+          }
+          return next
+        },
+        { replace: true },
+      )
+    },
+    [updateSearchParams],
+  )
+
+  // Used by the region dropdown and breadcrumb navigation.
+  // Clears watershed state since the user is navigating to a different scope.
+  const handleRegionDropdownChange = useCallback(
+    (region: RegionOption) => {
+      handleRegionChange(region)
+      handleWatershedChange(null)
+      clearSelectedFeature()
+    },
+    [handleRegionChange, handleWatershedChange, clearSelectedFeature],
   )
 
   const handleYearChange = useCallback(
@@ -220,7 +262,7 @@ export default function MapContainer() {
         />
         <RegionSelect
           selectedRegion={selectedRegion}
-          onRegionChange={handleRegionChange}
+          onRegionChange={handleRegionDropdownChange}
           breadcrumb={breadcrumb}
           setBreadcrumb={setBreadcrumb}
         />
@@ -232,6 +274,9 @@ export default function MapContainer() {
         sedExportSubLayerValue={subSedLayerValue}
         selectedRegion={selectedRegion}
         onRegionChange={handleRegionChange}
+        onWatershedChange={handleWatershedChange}
+        initialWatershedId={initialWatershedId}
+        hasExplicitViewState={hasExplicitViewState}
         setBreadcrumb={setBreadcrumb}
         initialViewState={{
           longitude: lng ?? selectedRegion.centerCoord.lng,

--- a/src/components/MapContainer/MapContainer.tsx
+++ b/src/components/MapContainer/MapContainer.tsx
@@ -143,13 +143,13 @@ export default function MapContainer() {
     (newWatershedId: string | null) => {
       updateSearchParams(
         (prev) => {
-          const next = new URLSearchParams(prev)
+          const nextSearchParams = new URLSearchParams(prev)
           if (newWatershedId) {
-            next.set('watershed', newWatershedId)
+            nextSearchParams.set('watershed', newWatershedId)
           } else {
-            next.delete('watershed')
+            nextSearchParams.delete('watershed')
           }
-          return next
+          return nextSearchParams
         },
         { replace: true },
       )

--- a/src/components/MapContainer/MapContainer.tsx
+++ b/src/components/MapContainer/MapContainer.tsx
@@ -118,12 +118,16 @@ export default function MapContainer() {
     shouldSyncLayersParam,
   ])
 
+  const watershedParam = searchParams.get('watershed')
+
   useEffect(() => {
     setSelectedRegion(initialRegion)
-    setBreadcrumb(
-      initialRegion.grouping > 0 ? [defaultGlobalRegionOption, initialRegion] : [initialRegion],
-    )
-  }, [initialRegion])
+    if (!watershedParam) {
+      setBreadcrumb(
+        initialRegion.grouping > 0 ? [defaultGlobalRegionOption, initialRegion] : [initialRegion],
+      )
+    }
+  }, [initialRegion, watershedParam])
 
   const handleRegionChange = useCallback(
     (region: RegionOption) => {

--- a/src/components/RegionSelect/RegionSelect.tsx
+++ b/src/components/RegionSelect/RegionSelect.tsx
@@ -86,10 +86,8 @@ export default function RegionSelect({
     if (region.grouping > 0) {
       jumpToRegion(region)
     }
-    if (selectedRegion !== region) {
-      onRegionChange(region)
-      prepBreadcrumb(region)
-    }
+    onRegionChange(region)
+    prepBreadcrumb(region)
   }
 
   return (

--- a/src/utils/chartUtils.ts
+++ b/src/utils/chartUtils.ts
@@ -141,6 +141,10 @@ export const updateChartData = (
     chartSeriesData = getBoundaryFileChartData(feature.properties)
     //more sources to go here
   }
+  if (!chartSeriesData) {
+    setChartData(null)
+    return
+  }
   const hasData = Object.values(chartSeriesData).some((series) =>
     Object.values(series as Record<string, object>).some(
       (yearData) => Object.keys(yearData).length > 0,

--- a/src/utils/mapUtils.ts
+++ b/src/utils/mapUtils.ts
@@ -1,6 +1,12 @@
 import { RegionOption } from '../types/RegionDataTypes'
 import { regionOptions } from '../data/regionData'
-import { LngLatBounds, Map, MapGeoJSONFeature, MapLayerMouseEvent } from 'maplibre-gl'
+import {
+  FilterSpecification,
+  LngLatBounds,
+  Map,
+  MapGeoJSONFeature,
+  MapLayerMouseEvent,
+} from 'maplibre-gl'
 import { RefObject } from 'react'
 import { LayerInfo, SubLayerInfo } from '../types/MapDataTypes'
 import { atlasBenthicColors, transparent } from '../data/mapData'
@@ -147,6 +153,62 @@ export const mapToggleChange = (
     const yearMatch = layer.year === undefined || layer.year === year
     return layerMatch && yearMatch ? { ...layer, isLayerOn: checked } : layer
   })
+}
+
+/**
+ * Queries a vector tile source for a feature, retrying as tiles load.
+ * Calls onResult with the feature once found, or null on timeout.
+ * Returns a cancel function (suitable as useEffect cleanup).
+ * Reusable for any vector source that needs async feature lookup (watershed, plume, etc.).
+ */
+export function querySourceFeatureWhenReady(
+  map: Map,
+  sourceId: string,
+  sourceLayer: string,
+  filter: FilterSpecification,
+  onResult: (feature: MapGeoJSONFeature | null) => void,
+  timeoutMs = 10_000,
+): () => void {
+  let settled = false
+
+  const tryQuery = (): MapGeoJSONFeature | null => {
+    const features = map.querySourceFeatures(sourceId, { sourceLayer, filter })
+    return features.length > 0 ? (features[0] as MapGeoJSONFeature) : null
+  }
+
+  const settle = (result: MapGeoJSONFeature | null) => {
+    if (settled) {
+      return
+    }
+    settled = true
+    map.off('sourcedata', onSourceData)
+    clearTimeout(timeoutId)
+    onResult(result)
+  }
+
+  // Try immediately
+  const immediate = tryQuery()
+  if (immediate) {
+    settled = true
+    onResult(immediate)
+    return () => {}
+  }
+
+  // Retry on each sourcedata event as tiles stream in
+  const onSourceData = (e: { sourceId?: string }) => {
+    if (settled || e.sourceId !== sourceId) {
+      return
+    }
+    const feature = tryQuery()
+    if (feature) {
+      settle(feature)
+    }
+  }
+  map.on('sourcedata', onSourceData)
+
+  const timeoutId = setTimeout(() => settle(null), timeoutMs)
+
+  return () => settle(null)
 }
 
 export function mapRegionSelected(feature: MapGeoJSONFeature): RegionOption {

--- a/src/utils/routeUtils.ts
+++ b/src/utils/routeUtils.ts
@@ -16,6 +16,18 @@ export function getValidRegion(regionFromSearchParam: string | null): RegionOpti
   return found ?? defaultGlobalRegionOption
 }
 
+/**
+ * Basic format check only — returns trimmed string or null.
+ * Full validation (does this ID exist?) happens after the map loads
+ * by querying the vector tile source.
+ */
+export function getValidWatershed(watershedFromSearchParam: string | null): string | null {
+  if (!watershedFromSearchParam || watershedFromSearchParam.trim() === '') {
+    return null
+  }
+  return watershedFromSearchParam.trim()
+}
+
 export function getValidYear(yearFromSearchParam: string | null) {
   const parsedYear = Number(yearFromSearchParam)
   return availableYears.includes(parsedYear) ? parsedYear : defaultYear


### PR DESCRIPTION
## Summary
- Add `?watershed={id}` to URL on watershed click
- Restore selection on page load: highlight, charts, breadcrumb, map position
- Clear watershed state when navigating via region dropdown/breadcrumb
- Extract `querySourceFeatureWhenReady` to mapUtils (reusable for future plume routing)
- Fix pre-existing null guard in `chartUtils.updateChartData`

## Design decisions
- **`initialWatershedId` via `useState`**: Captured once at mount so clicks don't re-trigger restoration. Tradeoff: browser back/forward won't auto-restore (matches existing region routing behavior).
- **`setFeatureState` deferred until queryable**: Early calls get wiped by react-map-gl's source initialization. Wait for tiles to load, then highlight and process in one synchronous block.
- **`feature.source` patched before processing**: `querySourceFeatures` doesn't populate `source` on returned features. Charts need it to identify the data source.
- **RegionSelect guard removed**: Previously skipped `onRegionChange` when re-selecting the same region, which prevented watershed clearing from breadcrumb navigation.

## Test plan
- [ ] Click watershed → URL updates, breadcrumb and charts populate
- [ ] Refresh with watershed param → selection restores
- [ ] Refresh with explicit lat/lng/zoom → map respects position instead of fitting to watershed
- [ ] Invalid watershed ID → silently removed after timeout
- [ ] Region dropdown/breadcrumb → watershed clears

## Every PR

Before merging, the developer of this pull request has checked the following:

- [x] Changes have been tested locally without errors
- [x] Lint has run and any errors have been resolved
- [x] Prettier has run on any changed files
- [x] Storybook stories have run and any errors have been resolved
- [x] Pre-existing unit tests have run and passed
  - [x] Unit tests have been added or updated, where possible, to prevent future regressions

## Post-Merge

- [ ] Code has merged and build success is confirmed in 'Actions'
- [ ] The corresponding Trello ticket has moved to the appropriate list (likely User-QA)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added watershed selection capability with URL parameter support for sharing and bookmarking specific locations
  * Automatic restoration of previously selected watersheds when navigating via URL

* **Bug Fixes**
  * Improved chart data handling and region selection state management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->