### PR TITLE
fix: [C165] Revert sediment load bar color to blue and remove Surface Water from Land Use chart

### DIFF
--- a/src/data/chartSeriesData.ts
+++ b/src/data/chartSeriesData.ts
@@ -9,7 +9,6 @@ export const chartSeriesConfig: ChartSeriesConfig = {
       shrubland_grassland: '#B0B006',
       mixed_forest: '#609C30',
       high_canopy_forest: '#065106',
-      surface_water: '#0E39D6',
       cropland: '#FF7D00',
       built_up: '#64DCDC',
     },
@@ -35,7 +34,7 @@ export const chartSeriesConfig: ChartSeriesConfig = {
   'charts.sediment_load_historical': {
     barmode: 'group',
     legendColors: {
-      sediment: '#e7cb11',
+      sediment: '#003F5C',
     },
     name: 'charts.sediment_load_historical',
     tracePrefix: '',

--- a/src/data/tempLandUseChartData.json
+++ b/src/data/tempLandUseChartData.json
@@ -64,16 +64,5 @@
     "width": 2,
     "x": ["2000", "2005", "2010", "2015", "2020"],
     "y": [12, 11, 14, 8, 10]
-  },
-  {
-    "type": "bar",
-    "marker": {
-      "color": "#0E39D6"
-    },
-    "hovertemplate": "Year: %{x}<br />Surface water: %{y}%<extra></extra>",
-    "name": "Surface water",
-    "width": 2,
-    "x": ["2000", "2005", "2010", "2015", "2020"],
-    "y": [18, 16, 14, 15, 13]
   }
 ]

--- a/src/data/tempSedimentLoadChartData.json
+++ b/src/data/tempSedimentLoadChartData.json
@@ -2,7 +2,7 @@
   {
     "type": "bar",
     "marker": {
-      "color": "#e7cb11"
+      "color": "#003F5C"
     },
     "hovertemplate": "Year: %{x}<br />Sediment: %{y:.2f}T<extra></extra>",
     "name": "Sediment",

--- a/src/tests/chartUtils.test.ts
+++ b/src/tests/chartUtils.test.ts
@@ -12,7 +12,6 @@ const groupedProperties: LulcAndSedimentSeriesData = {
     high_canopy_forest: { '2010': 3 },
     mixed_forest: { '2015': 4 },
     shrubland_grassland: { '2020': 6 },
-    surface_water: { '2000': 1 },
   },
   sediment_load_historical: {
     sediment: {},
@@ -35,7 +34,6 @@ const emptyChartSeriesData: LulcAndSedimentSeriesData = {
     high_canopy_forest: {},
     mixed_forest: {},
     shrubland_grassland: {},
-    surface_water: {},
   },
   sediment_load_historical: {
     sediment: {},
@@ -88,7 +86,6 @@ describe('chart data utilities', () => {
         HC_Forest_pct_2010: 3,
         M_Forest_pct_2015: 4,
         Shrub_Grass_pct_2020: 6,
-        Water_pct_2000: 1,
         name: 'Test',
         watershed_id: 123,
       }

--- a/src/tests/mockChartData.json
+++ b/src/tests/mockChartData.json
@@ -64,16 +64,5 @@
     "width": 2,
     "x": ["2020"],
     "y": [6]
-  },
-  {
-    "type": "bar",
-    "marker": {
-      "color": "#0E39D6"
-    },
-    "hovertemplate": "Year: %{x}<br />Surface water: %{y}%<extra></extra>",
-    "name": "Surface water",
-    "width": 2,
-    "x": ["2000"],
-    "y": [1]
   }
 ]

--- a/src/utils/chartUtils.ts
+++ b/src/utils/chartUtils.ts
@@ -16,7 +16,6 @@ export interface LulcAndSedimentSeriesData {
     high_canopy_forest: object
     mixed_forest: object
     shrubland_grassland: object
-    surface_water: object
   }
   sediment_load_historical: {
     sediment: object
@@ -33,7 +32,6 @@ export const getBoundaryFileChartData = (pointProperties): LulcAndSedimentSeries
       high_canopy_forest: {},
       mixed_forest: {},
       shrubland_grassland: {},
-      surface_water: {},
     },
     sediment_load_historical: {
       sediment: {},
@@ -73,9 +71,6 @@ export const getBoundaryFileChartData = (pointProperties): LulcAndSedimentSeries
           break
         case 'Shrub_Grass_pct_':
           chartSeriesData.land_use_historical.shrubland_grassland[year] = val
-          break
-        case 'Water_pct_':
-          chartSeriesData.land_use_historical.surface_water[year] = val
           break
         case 'sed_export_':
           chartSeriesData.sediment_load_historical.sediment[year] = val


### PR DESCRIPTION
Restore sediment_load_historical bar color to #003F5C (was changed to yellow #e7cb11 in #76 (C147)).
Remove surface_water series from the Land Use chart config, processing logic, mock data, and tests.

## Every PR

Before merging, the developer of this pull request has checked the following:

- [ ] Changes have been tested locally without errors
- [ ] Lint has run and any errors have been resolved
- [ ] Prettier has run on any changed files
- [ ] Storybook stories have run and any errors have been resolved
- [ ] Pre-existing unit tests have run and passed
  - [ ] Unit tests have been added or updated, where possible, to prevent future regressions

## Post-Merge

- [ ] Code has merged and build success is confirmed in 'Actions'
- [ ] The corresponding Trello ticket has moved to the appropriate list (likely User-QA)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Removed the Surface water land-use category and its historical data from charts
  * Updated the sediment load visualization color for improved clarity

* **Tests**
  * Updated test fixtures, mock chart data, and test assertions to reflect the removal of Surface water data and chart styling changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->