### PR TITLE
feat: [C152] Ocean sediment dispersal workflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@maptiler/sdk": "^3.5.0",
     "@mui/icons-material": "^7.2.0",
     "@mui/material": "^7.2.0",
+    "@turf/boolean-point-in-polygon": "^7.3.4",
     "eslint-plugin-react-dom": "^1.52.3",
     "i18next": "^25.3.2",
     "i18next-resources-to-backend": "^1.2.1",

--- a/src/assets/crosshair-cursor.svg
+++ b/src/assets/crosshair-cursor.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none">
+  <line x1="10" y1="1" x2="10" y2="7" stroke="#00FF01" stroke-width="2" stroke-linecap="round"/>
+  <line x1="10" y1="13" x2="10" y2="19" stroke="#00FF01" stroke-width="2" stroke-linecap="round"/>
+  <line x1="1" y1="10" x2="7" y2="10" stroke="#00FF01" stroke-width="2" stroke-linecap="round"/>
+  <line x1="13" y1="10" x2="19" y2="10" stroke="#00FF01" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/src/components/BaseMap/BaseMap.module.scss
+++ b/src/components/BaseMap/BaseMap.module.scss
@@ -14,3 +14,22 @@
 :global(.maplibregl-ctrl-bottom-right) {
   right: theme.$drawerWidth;
 }
+
+.plume-marker {
+  width: 15px;
+  height: 15px;
+  border: 2px solid theme.$accentBlue;
+  border-radius: 5px;
+  background: transparent;
+  pointer-events: none;
+}
+
+.snackbar-reload-button {
+  background: none;
+  border: none;
+  color: theme.$white;
+  text-decoration: underline;
+  cursor: pointer;
+  font-weight: theme.$regular;
+  padding-right: theme.$defaultSpacing;
+}

--- a/src/components/BaseMap/BaseMap.stories.ts
+++ b/src/components/BaseMap/BaseMap.stories.ts
@@ -4,6 +4,7 @@ import { layers } from '../../data/mapData'
 import { expect, waitFor } from 'storybook/test'
 import i18next from 'i18next'
 import { defaultGlobalRegionOption } from '../../data/regionData'
+// defaultGlobalRegionOption is still used for initialViewState coordinates
 
 const meta = {
   component: BaseMap,
@@ -17,9 +18,11 @@ export const Primary: Story = {
     sedExportSubLayerValue: 'pixel',
     onRegionChange: () => {},
     onWatershedChange: () => {},
+    onDispersalPointChange: () => {},
     initialWatershedId: null,
+    initialDispersalPoint: null,
+    dispersalPoint: null,
     hasExplicitViewState: false,
-    selectedRegion: defaultGlobalRegionOption,
     setBreadcrumb: () => {},
     initialViewState: {
       longitude: defaultGlobalRegionOption.centerCoord.lng,
@@ -48,9 +51,11 @@ export const Loading: Story = {
     mapLayers: layers,
     onRegionChange: () => {},
     onWatershedChange: () => {},
+    onDispersalPointChange: () => {},
     initialWatershedId: null,
+    initialDispersalPoint: null,
+    dispersalPoint: null,
     hasExplicitViewState: false,
-    selectedRegion: defaultGlobalRegionOption,
     setBreadcrumb: () => {},
     sedExportSubLayerValue: 'pixel',
     initialViewState: {

--- a/src/components/BaseMap/BaseMap.stories.ts
+++ b/src/components/BaseMap/BaseMap.stories.ts
@@ -26,6 +26,7 @@ export const Primary: Story = {
       latitude: defaultGlobalRegionOption.centerCoord.lat,
       zoom: defaultGlobalRegionOption.zoomLevel,
     },
+    selectedYear: 2000,
     onMapMoveEnd: () => {},
   },
   play: async ({ canvas }) => {
@@ -57,6 +58,7 @@ export const Loading: Story = {
       latitude: defaultGlobalRegionOption.centerCoord.lat,
       zoom: defaultGlobalRegionOption.zoomLevel,
     },
+    selectedYear: 2000,
     onMapMoveEnd: () => {},
   },
   // play: async ({ canvasElement }) => {

--- a/src/components/BaseMap/BaseMap.tsx
+++ b/src/components/BaseMap/BaseMap.tsx
@@ -1,5 +1,6 @@
 import React, {
   Dispatch,
+  RefObject,
   SetStateAction,
   useCallback,
   useEffect,
@@ -61,13 +62,16 @@ import crosshairCursorUrl from '../../assets/crosshair-cursor.svg?url'
 
 const plumeCrosshairCursor = `url("${crosshairCursorUrl}") 10 10, crosshair`
 
-const getRegionByLabel = (regionLabel) => regionOptions.find((opt) => opt.label === regionLabel)
+const getRegionByLabel = (regionLabel: string | undefined) =>
+  regionOptions.find((opt) => opt.label === regionLabel)
 
 const buildBreadcrumb = (
   featureProperties: Record<string, unknown> | null | undefined,
   subRegion: RegionOption,
 ): { breadcrumb: RegionOption[]; addtlRegion: RegionOption | undefined } => {
-  const countryOrRegion = featureProperties?.TERRITORY1 || featureProperties?.REALM
+  const countryOrRegion = (featureProperties?.TERRITORY1 || featureProperties?.REALM) as
+    | string
+    | undefined
   const addtlRegion = getRegionByLabel(countryOrRegion)
   const breadcrumb: RegionOption[] = [defaultGlobalRegionOption]
   if (addtlRegion) {
@@ -116,10 +120,12 @@ interface HandleMapClickParamProps {
   selectedYear: number
   setClickedPlumePoint: (point: { lng: number; lat: number } | null) => void
   setBreadcrumb: Dispatch<SetStateAction<RegionOption[]>>
+  requestIdRef: RefObject<number>
 }
 
 const handleMapClick = async (e: MapMouseEvent, clickParams: HandleMapClickParamProps) => {
-  const { map, watershedLayer, selectedYear, setClickedPlumePoint, setBreadcrumb } = clickParams
+  const { map, watershedLayer, selectedYear, setClickedPlumePoint, setBreadcrumb, requestIdRef } =
+    clickParams
   const { setTopPolygonsFill } = useMapStore.getState()
   const { setSelectedPlumeWatershedStats } = useSelectedFeatureStore.getState()
   const { clearSelectedFeature } = useSelectedFeatureStore.getState()
@@ -127,7 +133,13 @@ const handleMapClick = async (e: MapMouseEvent, clickParams: HandleMapClickParam
   clearSelectedFeature()
   setClickedPlumePoint({ lng: e.lngLat.lng, lat: e.lngLat.lat })
 
+  const requestId = ++requestIdRef.current
   const currentAllYearZonalStats = await getAllYearZonalStats(e.lngLat)
+
+  if (requestId !== requestIdRef.current) {
+    return
+  }
+
   setSelectedPlumeWatershedStats(currentAllYearZonalStats)
 
   const currentYearZonalStats = currentAllYearZonalStats[selectedYear]
@@ -329,6 +341,8 @@ export default function BaseMap({
   const polygonClickRef = useRef<string | number | null>(null)
   const polygonHoverBoundRef = useRef<((e) => void) | null>(null)
   const polygonClickBoundRef = useRef<((e) => void) | null>(null)
+  // Tracks the latest plume click fetch so earlier, slower responses don't overwrite newer ones.
+  const plumeRequestIdRef = useRef(0)
 
   const mapLayersLoadingError = useMemo(() => {
     return Object.keys(layerErrors).length > 0
@@ -590,6 +604,7 @@ export default function BaseMap({
         selectedYear,
         setClickedPlumePoint,
         setBreadcrumb,
+        requestIdRef: plumeRequestIdRef,
       })
 
     polygonHoverBoundRef.current = onWatershedHover

--- a/src/components/BaseMap/BaseMap.tsx
+++ b/src/components/BaseMap/BaseMap.tsx
@@ -52,6 +52,9 @@ import { LayerInfo } from '../../types/MapDataTypes'
 import { useMapStore } from '../../stores/mapStore'
 import { transparent } from '../../data/mapData'
 import { defaultGlobalRegionOption, regionOptions } from '../../data/regionData'
+import crosshairCursorUrl from '../../assets/crosshair-cursor.svg?url'
+
+const plumeCrosshairCursor = `url("${crosshairCursorUrl}") 10 10, crosshair`
 
 const getRegionByLabel = (regionLabel) => regionOptions.find((opt) => opt.label === regionLabel)
 
@@ -164,6 +167,43 @@ function PmTileLayers({ layer, index }) {
         layout={{
           visibility: layer.isLayerOn ? 'visible' : 'none',
         }}
+        paint={{
+          'line-color': layer.outlineColor,
+          'line-dasharray': layer.outlineStyle ? [0, 2, 5] : [2, 0],
+        }}
+      />
+    </Source>
+  )
+}
+
+// Transparent fill layer so mousemove/mouseleave fire over the full plume area,
+// not just the outline stroke. Line layer preserves the visual yellow outline.
+function PlumeLayers({ layer, index }) {
+  return (
+    <Source
+      id={layer.sourceId}
+      key={`${layer.sourceId}-source`}
+      type="vector"
+      url={`pmtiles://${layer.link}`}
+    >
+      <Layer
+        id={layer.layerId}
+        type="fill"
+        key={`${layer.layerId}-fill-${index}`}
+        source={layer.sourceId}
+        source-layer={layer.sourceFileName}
+        beforeId="watershed"
+        layout={{ visibility: layer.isLayerOn ? 'visible' : 'none' }}
+        paint={{ 'fill-color': transparent }}
+      />
+      <Layer
+        id={`${layer.layerId}-lines`}
+        type="line"
+        key={`${layer.layerId}-lines-${index}`}
+        source={layer.sourceId}
+        source-layer={layer.sourceFileName}
+        beforeId="watershed"
+        layout={{ visibility: layer.isLayerOn ? 'visible' : 'none' }}
         paint={{
           'line-color': layer.outlineColor,
           'line-dasharray': layer.outlineStyle ? [0, 2, 5] : [2, 0],
@@ -473,6 +513,13 @@ export default function BaseMap({
       map.getCanvas().style.cursor = ''
       clearPolygonHover(map, polygonHoverRef, watershedLayer)
     })
+
+    map.on('mousemove', 'plumes', () => {
+      map.getCanvas().style.cursor = plumeCrosshairCursor
+    })
+    map.on('mouseleave', 'plumes', () => {
+      map.getCanvas().style.cursor = ''
+    })
   }
 
   return (
@@ -505,6 +552,8 @@ export default function BaseMap({
         {mapLayers.map((layer: LayerInfo, index) => {
           if (layer.layerId === 'watershed') {
             return null // rendered above, always present
+          } else if (layer.layerId === 'plumes') {
+            return isMapLoaded && <PlumeLayers key={`layer-${index}`} layer={layer} index={index} />
           } else if (layer.dataType === 'pmtiles') {
             return (
               isMapLoaded && <PmTileLayers key={`layer-${index}`} layer={layer} index={index} />

--- a/src/components/BaseMap/BaseMap.tsx
+++ b/src/components/BaseMap/BaseMap.tsx
@@ -135,13 +135,13 @@ const handleMapClick = async (
   const exampleTopWatershedIds = [974529, 977314, 977908]
 
   for (let i = 2; i < 5; i++) {
-    if (topContributingWatershedIds.indexOf(currentYearZonalStats[`band_${i}`]?.majority) < 0) {
-      topContributingWatershedIds.push(currentYearZonalStats[`band_${i}`]?.majority)
+    const watershedId = currentYearZonalStats[`band_${i}`]?.majority
+    if (typeof watershedId === 'number' && topContributingWatershedIds.indexOf(watershedId) < 0) {
+      topContributingWatershedIds.push(watershedId)
     }
   }
 
-  const topContributingWatershedColorFills = ['#FFA600', '#D86D83', '#7A5195']
-  setTopPolygonsFill('watershed', exampleTopWatershedIds, topContributingWatershedColorFills)
+  setTopPolygonsFill('watershed', exampleTopWatershedIds) //TODO: replace with topContributingWatershedIds when real stats are available
 }
 
 function WatershedLayers({ layer, index }) {

--- a/src/components/BaseMap/BaseMap.tsx
+++ b/src/components/BaseMap/BaseMap.tsx
@@ -40,6 +40,7 @@ import {
   createPolygonClickHandler,
   createPolygonHoverHandler,
   querySourceFeatureWhenReady,
+  querySourceFeatureAtPointWhenReady,
   setPolygonSelect,
   getAllYearZonalStats,
 } from '../../utils/mapUtils'
@@ -170,7 +171,9 @@ const applyPlumeStats = ({
 
   for (let i = 2; i < 5; i++) {
     const watershedId = currentYearZonalStats[`band_${i}`]?.majority
-    topContributingWatershedIds.push(watershedId)
+    if (typeof watershedId === 'number' && topContributingWatershedIds.indexOf(watershedId) < 0) {
+      topContributingWatershedIds.push(watershedId)
+    }
   }
 
   // TODO: replace with topContributingWatershedIds when real stats are available
@@ -390,6 +393,7 @@ export default function BaseMap({
     [mapLayers],
   )
   const watershedLayer = watershedIndex >= 0 ? mapLayers[watershedIndex] : undefined
+  const plumeLayer = useMemo(() => mapLayers.find((l) => l.layerId === 'plumes'), [mapLayers])
   const benthicSubLayerFillExpression = useMemo(
     () => [
       'case',
@@ -594,39 +598,46 @@ export default function BaseMap({
 
   // Plume restoration from URL
   useEffect(() => {
-    if (!isMapLoaded || !initialDispersalPoint || !watershedLayer) {
-      return
+    if (!isMapLoaded || !initialDispersalPoint || !watershedLayer || !plumeLayer) {
+      return undefined
     }
 
     const map = mapRef.current?.getMap()
     if (!map) {
-      return
+      return undefined
     }
 
-    // Validate the dispersal point falls within the plume layer.
-    // If the param was manually edited or the data changed, clear it.
-    const pixel = map.project([initialDispersalPoint.lng, initialDispersalPoint.lat])
-    const plumeFeatures = map.queryRenderedFeatures(pixel, { layers: ['plumes'] })
-    if (plumeFeatures.length === 0) {
-      onDispersalPointChange(null)
-      return
-    }
+    // Validate the dispersal point falls within the plume source, retrying as tiles stream in.
+    // Uses querySourceFeatures (viewport-independent) to avoid clearing valid URL params that
+    // are off-screen at load time, or before PMTiles have finished loading.
+    return querySourceFeatureAtPointWhenReady(
+      map,
+      plumeLayer.sourceId,
+      plumeLayer.sourceFileName,
+      initialDispersalPoint,
+      (feature) => {
+        if (!feature) {
+          onDispersalPointChange(null)
+          return
+        }
 
-    void (async () => {
-      const allYearStats = await getAllYearZonalStats(initialDispersalPoint)
-      applyPlumeStats({
-        map,
-        watershedLayer,
-        point: initialDispersalPoint,
-        allYearStats,
-        selectedYear,
-        setBreadcrumb,
-      })
-    })()
-    // onDispersalPointChange intentionally omitted — this effect is for initial restoration only.
+        void (async () => {
+          const allYearStats = await getAllYearZonalStats(initialDispersalPoint)
+          applyPlumeStats({
+            map,
+            watershedLayer,
+            point: initialDispersalPoint,
+            allYearStats,
+            selectedYear,
+            setBreadcrumb,
+          })
+        })()
+      },
+    )
+    // onDispersalPointChange, setBreadcrumb, selectedYear intentionally omitted — this effect is for initial restoration only.
     // initialDispersalPoint is stable (captured once at mount) so this effect only runs once when the map loads.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isMapLoaded, initialDispersalPoint, watershedLayer, setBreadcrumb, selectedYear])
+  }, [isMapLoaded, initialDispersalPoint, watershedLayer, plumeLayer])
 
   const handleMapLoad = () => {
     setIsMapLoaded(true)

--- a/src/components/BaseMap/BaseMap.tsx
+++ b/src/components/BaseMap/BaseMap.tsx
@@ -39,6 +39,7 @@ import {
   querySourceFeatureWhenReady,
   setPolygonSelect,
   prepareZonalStatsCall,
+  getAllYearZonalStats,
 } from '../../utils/mapUtils'
 import { SourceDataEvent } from '../../types/MapLayerErrorTypes'
 import { Snackbar } from '@mui/material'
@@ -97,26 +98,33 @@ const handleError = (
 const handleMapClick = async (
   e,
   map,
-  setClickedOceanPoint: (point: { lng: number; lat: number } | null) => void,
+  selectedYear: number,
+  setClickedPlumePoint: (point: { lng: number; lat: number } | null) => void,
 ) => {
   const { setTopPolygonsFill } = useMapStore.getState()
+  const { setSelectedPlumeWatershedStats } = useSelectedFeatureStore.getState()
+  const { clearSelectedFeature } = useSelectedFeatureStore.getState()
+
   const plumeFeatures = map.queryRenderedFeatures(e.point, { layers: ['plumes'] })
 
   if (plumeFeatures.length === 0) {
     return
   }
 
-  setClickedOceanPoint({ lng: e.lngLat.lng, lat: e.lngLat.lat })
+  clearSelectedFeature()
+  setClickedPlumePoint({ lng: e.lngLat.lng, lat: e.lngLat.lat })
 
-  const zonalStats: ZonalStatsBand[] = await prepareZonalStatsCall(e.lngLat)
+  const currentAllYearZonalStats = await getAllYearZonalStats(e.lngLat)
+  setSelectedPlumeWatershedStats(currentAllYearZonalStats)
 
+  const currentYearZonalStats = currentAllYearZonalStats[selectedYear]
   const topContributingWatershedIds: number[] = []
   // TODO: example ids used temporarily - actual zonal stats ids are not yet synced with watershed polygon ids
   const exampleTopWatershedIds = [974529, 977314, 977908]
 
   for (let i = 2; i <= 5; i++) {
-    if (topContributingWatershedIds.indexOf(zonalStats[`band_${i}`].majority) < 0) {
-      topContributingWatershedIds.push(zonalStats[`band_${i}`].majority)
+    if (topContributingWatershedIds.indexOf(currentYearZonalStats[`band_${i}`].majority) < 0) {
+      topContributingWatershedIds.push(currentYearZonalStats[`band_${i}`].majority)
     }
   }
 
@@ -253,6 +261,7 @@ interface BaseMapProps {
   onRegionChange: (region: RegionOption) => void
   onWatershedChange: (id: string | null) => void
   initialWatershedId: string | null
+  selectedYear: number
   hasExplicitViewState: boolean
   setBreadcrumb: Dispatch<SetStateAction<RegionOption[]>>
   initialViewState: {
@@ -270,6 +279,7 @@ export default function BaseMap({
   onRegionChange,
   onWatershedChange,
   initialWatershedId,
+  selectedYear,
   hasExplicitViewState,
   setBreadcrumb,
   initialViewState,
@@ -279,7 +289,7 @@ export default function BaseMap({
   const { isDesktopWidth } = useResponsive()
 
   const [isMapLoaded, setIsMapLoaded] = useState(false)
-  const [clickedOceanPoint, setClickedOceanPoint] = useState<{
+  const [clickedPlumePoint, setClickedPlumePoint] = useState<{
     lng: number
     lat: number
   } | null>(null)
@@ -412,7 +422,7 @@ export default function BaseMap({
       return
     }
 
-    const onClick = (e) => handleMapClick(e, map, setClickedOceanPoint)
+    const onClick = (e) => handleMapClick(e, map, selectedYear, setClickedPlumePoint)
     const onError = (e) => handleError(e, setLayerErrors)
     const onSourceData = (e) => handleSourceData(e, setLayerErrors)
 
@@ -579,10 +589,10 @@ export default function BaseMap({
             <NavigationControl position="bottom-right" showCompass={false} />
           </>
         )}
-        {clickedOceanPoint && (
+        {clickedPlumePoint && (
           <Marker
-            longitude={clickedOceanPoint.lng}
-            latitude={clickedOceanPoint.lat}
+            longitude={clickedPlumePoint.lng}
+            latitude={clickedPlumePoint.lat}
             anchor="center"
           >
             <div

--- a/src/components/BaseMap/BaseMap.tsx
+++ b/src/components/BaseMap/BaseMap.tsx
@@ -12,6 +12,7 @@ import {
   Layer,
   Map as MapGL,
   MapRef,
+  Marker,
   NavigationControl,
   ScaleControl,
   Source,
@@ -37,6 +38,7 @@ import {
   createPolygonHoverHandler,
   querySourceFeatureWhenReady,
   setPolygonSelect,
+  prepareZonalStatsCall,
 } from '../../utils/mapUtils'
 import { SourceDataEvent } from '../../types/MapLayerErrorTypes'
 import { Snackbar } from '@mui/material'
@@ -44,11 +46,12 @@ import { useTranslation } from 'react-i18next'
 import {
   mapFitBoundsDesktopConfig,
   mapFitBoundsMobileConfig,
+  oceanClickMarkerColor,
   polygonOutlineHoverColor,
   polygonOutlineSelectColor,
 } from '../../constants'
 import { useSelectedFeatureStore } from '../../stores/selectedFeatureStore'
-import { LayerInfo } from '../../types/MapDataTypes'
+import { LayerInfo, ZonalStatsBand } from '../../types/MapDataTypes'
 import { useMapStore } from '../../stores/mapStore'
 import { transparent } from '../../data/mapData'
 import { defaultGlobalRegionOption, regionOptions } from '../../data/regionData'
@@ -89,6 +92,36 @@ const handleError = (
     ...prev,
     [e.type]: e.error?.message || 'Failed to load layer',
   }))
+}
+
+const handleMapClick = async (
+  e,
+  map,
+  setClickedOceanPoint: (point: { lng: number; lat: number } | null) => void,
+) => {
+  const { setTopPolygonsFill } = useMapStore.getState()
+  const plumeFeatures = map.queryRenderedFeatures(e.point, { layers: ['plumes'] })
+
+  if (plumeFeatures.length === 0) {
+    return
+  }
+
+  setClickedOceanPoint({ lng: e.lngLat.lng, lat: e.lngLat.lat })
+
+  const zonalStats: ZonalStatsBand[] = await prepareZonalStatsCall(e.lngLat)
+
+  const topContributingWatershedIds: number[] = []
+  // TODO: example ids used temporarily - actual zonal stats ids are not yet synced with watershed polygon ids
+  const exampleTopWatershedIds = [974529, 977314, 977908]
+
+  for (let i = 2; i <= 5; i++) {
+    if (topContributingWatershedIds.indexOf(zonalStats[`band_${i}`].majority) < 0) {
+      topContributingWatershedIds.push(zonalStats[`band_${i}`].majority)
+    }
+  }
+
+  const topContributingWatershedColorFills = ['#FFA600', '#D86D83', '#7A5195']
+  setTopPolygonsFill('watershed', exampleTopWatershedIds, topContributingWatershedColorFills)
 }
 
 function WatershedLayers({ layer, index }) {
@@ -246,7 +279,14 @@ export default function BaseMap({
   const { isDesktopWidth } = useResponsive()
 
   const [isMapLoaded, setIsMapLoaded] = useState(false)
-  const mapRef = useRef<MapRef | null>(useMapStore.getState().mapReference)
+  const [clickedOceanPoint, setClickedOceanPoint] = useState<{
+    lng: number
+    lat: number
+  } | null>(null)
+  const mapRef = useRef<MapRef | null>(useMapStore((s) => s.mapReference))
+  const setMapRef = useMapStore((s) => s.setMapRef)
+  const benthicFillColors = useMapStore((s) => s.benthicMapSubLayerColors)
+
   const [layerErrors, setLayerErrors] = useState<Record<string, string>>({})
   const polygonHoverRef = useRef<string | number | null>(null)
   const polygonClickRef = useRef<string | number | null>(null)
@@ -372,14 +412,17 @@ export default function BaseMap({
       return
     }
 
+    const onClick = (e) => handleMapClick(e, map, setClickedOceanPoint)
     const onError = (e) => handleError(e, setLayerErrors)
     const onSourceData = (e) => handleSourceData(e, setLayerErrors)
 
+    map.on('click', onClick)
     map.on('error', onError)
     map.on('sourcedata', onSourceData)
 
     // eslint-disable-next-line consistent-return
     return () => {
+      map.off('click', onClick)
       map.off('error', onError)
       map.off('sourcedata', onSourceData)
     }
@@ -450,7 +493,6 @@ export default function BaseMap({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isMapLoaded, initialWatershedId, watershedLayer, hasExplicitViewState])
 
-  const benthicFillColors = useMapStore((s) => s.benthicMapSubLayerColors)
   const benthicSubLayerFillExpression = useMemo(
     () => [
       'case',
@@ -471,12 +513,6 @@ export default function BaseMap({
     [benthicFillColors],
   )
 
-  useEffect(() => {
-    if (mapRef.current) {
-      useMapStore.getState().setMapRef(mapRef.current)
-    }
-  }, [isMapLoaded])
-
   const handleMapLoad = () => {
     setIsMapLoaded(true)
 
@@ -484,6 +520,8 @@ export default function BaseMap({
     if (!map || !watershedLayer) {
       return
     }
+
+    setMapRef(mapRef.current!)
 
     // prevent duplicate firing
     if (polygonHoverBoundRef.current) {
@@ -540,6 +578,24 @@ export default function BaseMap({
             <ScaleControl position="bottom-right" />
             <NavigationControl position="bottom-right" showCompass={false} />
           </>
+        )}
+        {clickedOceanPoint && (
+          <Marker
+            longitude={clickedOceanPoint.lng}
+            latitude={clickedOceanPoint.lat}
+            anchor="center"
+          >
+            <div
+              style={{
+                width: 15,
+                height: 15,
+                border: `2px solid ${oceanClickMarkerColor}`,
+                borderRadius: 5,
+                background: 'transparent',
+                pointerEvents: 'none',
+              }}
+            />
+          </Marker>
         )}
         {/* Watershed always rendered first so other layers can reference it via beforeId */}
         {isMapLoaded && watershedLayer && (

--- a/src/components/BaseMap/BaseMap.tsx
+++ b/src/components/BaseMap/BaseMap.tsx
@@ -53,13 +53,52 @@ import {
   polygonOutlineSelectColor,
 } from '../../constants'
 import { useSelectedFeatureStore } from '../../stores/selectedFeatureStore'
-import { LayerInfo } from '../../types/MapDataTypes'
+import { LayerInfo, ZonalStatsBand } from '../../types/MapDataTypes'
 import { useMapStore } from '../../stores/mapStore'
 import { transparent } from '../../data/mapData'
 import { defaultGlobalRegionOption, regionOptions } from '../../data/regionData'
 import crosshairCursorUrl from '../../assets/crosshair-cursor.svg?url'
 
 const plumeCrosshairCursor = `url("${crosshairCursorUrl}") 10 10, crosshair`
+
+interface ApplyPlumeStatsParams {
+  map: maplibregl.Map
+  watershedLayer: LayerInfo
+  point: { lng: number; lat: number }
+  allYearStats: Record<number, ZonalStatsBand>
+  selectedYear: number
+  setBreadcrumb: Dispatch<SetStateAction<RegionOption[]>>
+}
+
+interface HandleMapClickParamProps {
+  map: maplibregl.Map
+  watershedLayer: LayerInfo
+  selectedYear: number
+  setBreadcrumb: Dispatch<SetStateAction<RegionOption[]>>
+  onDispersalPointChange: (point: { lat: number; lng: number } | null) => void
+  clearWatershedSelection: () => void
+  requestIdRef: RefObject<number>
+}
+
+interface BaseMapProps {
+  mapLayers: LayerInfo[]
+  sedExportSubLayerValue: 'pixel' | 'watershed'
+  onRegionChange: (region: RegionOption) => void
+  onWatershedChange: (id: string | null) => void
+  onDispersalPointChange(point: { lat: number; lng: number } | null): void
+  initialWatershedId: string | null
+  initialDispersalPoint: { lat: number; lng: number } | null
+  dispersalPoint: { lat: number; lng: number } | null
+  selectedYear: number
+  hasExplicitViewState: boolean
+  setBreadcrumb: Dispatch<SetStateAction<RegionOption[]>>
+  initialViewState: {
+    longitude: number
+    latitude: number
+    zoom: number
+  }
+  onMapMoveEnd: (viewState: { latitude: number; longitude: number; zoom: number }) => void
+}
 
 const getRegionByLabel = (regionLabel: string | undefined) =>
   regionOptions.find((opt) => opt.label === regionLabel)
@@ -113,42 +152,25 @@ const handleError = (
   }))
 }
 
-interface HandleMapClickParamProps {
-  map: maplibregl.Map
-  watershedLayer: LayerInfo
-  selectedYear: number
-  setClickedPlumePoint: (point: { lng: number; lat: number } | null) => void
-  setBreadcrumb: Dispatch<SetStateAction<RegionOption[]>>
-  requestIdRef: RefObject<number>
-}
-
-const handleMapClick = async (e: MapMouseEvent, clickParams: HandleMapClickParamProps) => {
-  const { map, watershedLayer, selectedYear, setClickedPlumePoint, setBreadcrumb, requestIdRef } =
-    clickParams
+const applyPlumeStats = ({
+  map,
+  watershedLayer,
+  point,
+  allYearStats,
+  selectedYear,
+  setBreadcrumb,
+}: ApplyPlumeStatsParams): void => {
   const { setTopPolygonsFill } = useMapStore.getState()
   const { setSelectedPlumeWatershedStats } = useSelectedFeatureStore.getState()
-  const { clearSelectedFeature } = useSelectedFeatureStore.getState()
 
-  clearSelectedFeature()
-  setClickedPlumePoint({ lng: e.lngLat.lng, lat: e.lngLat.lat })
+  setSelectedPlumeWatershedStats(allYearStats)
 
-  const requestId = ++requestIdRef.current
-  const currentAllYearZonalStats = await getAllYearZonalStats(e.lngLat)
-
-  if (requestId !== requestIdRef.current) {
-    return
-  }
-
-  setSelectedPlumeWatershedStats(currentAllYearZonalStats)
-
-  const currentYearZonalStats = currentAllYearZonalStats[selectedYear]
+  const currentYearZonalStats = allYearStats[selectedYear]
   const topContributingWatershedIds: number[] = []
 
   for (let i = 2; i < 5; i++) {
     const watershedId = currentYearZonalStats[`band_${i}`]?.majority
-    if (typeof watershedId === 'number' && topContributingWatershedIds.indexOf(watershedId) < 0) {
-      topContributingWatershedIds.push(watershedId)
-    }
+    topContributingWatershedIds.push(watershedId)
   }
 
   // TODO: replace with topContributingWatershedIds when real stats are available
@@ -162,13 +184,44 @@ const handleMapClick = async (e: MapMouseEvent, clickParams: HandleMapClickParam
     id: 'plume',
     regionType: 'plume',
     label: 'Plume',
-    centerCoord: new LngLat(e.lngLat.lng, e.lngLat.lat),
+    centerCoord: new LngLat(point.lng, point.lat),
     zoomLevel: map.getZoom(),
     grouping: 3,
   })
 
   setBreadcrumb(breadcrumb)
-  setTopPolygonsFill('watershed', exampleTopWatershedIds) //TODO: replace with topContributingWatershedIds when real stats are available
+  setTopPolygonsFill('watershed', exampleTopWatershedIds) // TODO: replace with topContributingWatershedIds when real stats are available
+}
+
+const handleMapClick = async (e: MapMouseEvent, clickParams: HandleMapClickParamProps) => {
+  const {
+    map,
+    watershedLayer,
+    selectedYear,
+    setBreadcrumb,
+    onDispersalPointChange,
+    clearWatershedSelection,
+    requestIdRef,
+  } = clickParams
+
+  clearWatershedSelection()
+  onDispersalPointChange({ lng: e.lngLat.lng, lat: e.lngLat.lat })
+
+  const requestId = ++requestIdRef.current
+  const allYearStats = await getAllYearZonalStats(e.lngLat)
+
+  if (requestId !== requestIdRef.current) {
+    return
+  }
+
+  applyPlumeStats({
+    map,
+    watershedLayer,
+    point: e.lngLat,
+    allYearStats,
+    selectedYear,
+    setBreadcrumb,
+  })
 }
 
 function WatershedLayers({ layer, index }) {
@@ -293,31 +346,15 @@ function PlumeLayers({ layer, index }) {
   )
 }
 
-interface BaseMapProps {
-  mapLayers: LayerInfo[]
-  sedExportSubLayerValue: 'pixel' | 'watershed'
-  selectedRegion: RegionOption
-  onRegionChange: (region: RegionOption) => void
-  onWatershedChange: (id: string | null) => void
-  initialWatershedId: string | null
-  selectedYear: number
-  hasExplicitViewState: boolean
-  setBreadcrumb: Dispatch<SetStateAction<RegionOption[]>>
-  initialViewState: {
-    longitude: number
-    latitude: number
-    zoom: number
-  }
-  onMapMoveEnd: (viewState: { latitude: number; longitude: number; zoom: number }) => void
-}
-
 export default function BaseMap({
   mapLayers,
   sedExportSubLayerValue,
-  selectedRegion,
   onRegionChange,
   onWatershedChange,
+  onDispersalPointChange,
   initialWatershedId,
+  initialDispersalPoint,
+  dispersalPoint,
   selectedYear,
   hasExplicitViewState,
   setBreadcrumb,
@@ -327,38 +364,63 @@ export default function BaseMap({
   const { t } = useTranslation()
   const { isDesktopWidth } = useResponsive()
 
-  const [isMapLoaded, setIsMapLoaded] = useState(false)
-  const [clickedPlumePoint, setClickedPlumePoint] = useState<{
-    lng: number
-    lat: number
-  } | null>(null)
-  const mapRef = useRef<MapRef | null>(useMapStore((s) => s.mapReference))
   const setMapRef = useMapStore((s) => s.setMapRef)
+  const clearTopPolygonsFill = useMapStore((s) => s.clearTopPolygonsFill)
+  const benthicFillColors = useMapStore((s) => s.benthicMapSubLayerColors)
+  const clearSelectedFeature = useSelectedFeatureStore((s) => s.clearSelectedFeature)
+  const clearSelectedPlumeWatershedStats = useSelectedFeatureStore(
+    (s) => s.clearSelectedPlumeWatershedStats,
+  )
+  const setSelectedFeature = useSelectedFeatureStore((s) => s.setSelectedFeature)
+  const selectedFeature = useSelectedFeatureStore((s) => s.selectedFeature)
 
-  const [layerErrors, setLayerErrors] = useState<Record<string, string>>({})
+  const mapRef = useRef<MapRef | null>(useMapStore((s) => s.mapReference))
   const polygonHoverRef = useRef<string | number | null>(null)
   const polygonClickRef = useRef<string | number | null>(null)
   const polygonHoverBoundRef = useRef<((e) => void) | null>(null)
   const polygonClickBoundRef = useRef<((e) => void) | null>(null)
-  // Tracks the latest plume click fetch so earlier, slower responses don't overwrite newer ones.
-  const plumeRequestIdRef = useRef(0)
+  const plumeRequestIdRef = useRef(0) // Tracks the latest plume click fetch so earlier, slower responses don't overwrite newer ones.
 
-  const mapLayersLoadingError = useMemo(() => {
-    return Object.keys(layerErrors).length > 0
-  }, [layerErrors])
+  const [isMapLoaded, setIsMapLoaded] = useState(false)
+  const [layerErrors, setLayerErrors] = useState<Record<string, string>>({})
 
-  const clearTopPolygonsFill = useMapStore((s) => s.clearTopPolygonsFill)
-  const clearSelectedPlumeWatershedStats = useSelectedFeatureStore(
-    (s) => s.clearSelectedPlumeWatershedStats,
+  const mapLayersLoadingError = useMemo(() => Object.keys(layerErrors).length > 0, [layerErrors])
+  const watershedIndex = useMemo(
+    () => mapLayers.findIndex((l) => l.layerId === 'watershed'),
+    [mapLayers],
+  )
+  const watershedLayer = watershedIndex >= 0 ? mapLayers[watershedIndex] : undefined
+  const benthicSubLayerFillExpression = useMemo(
+    () => [
+      'case',
+      ['==', ['get', 'class_name'], 'Coral/Algae'],
+      benthicFillColors['coral_algae'],
+      ['==', ['get', 'class_name'], 'Benthic Microalgae'],
+      benthicFillColors['microalgal_mats'],
+      ['==', ['get', 'class_name'], 'Rock'],
+      benthicFillColors['rock'],
+      ['==', ['get', 'class_name'], 'Rubble'],
+      benthicFillColors['rubble'],
+      ['==', ['get', 'class_name'], 'Sand'],
+      benthicFillColors['sand'],
+      ['==', ['get', 'class_name'], 'Seagrass'],
+      benthicFillColors['seagrass'],
+      transparent, // Default / other
+    ],
+    [benthicFillColors],
   )
 
   const clearPlumeSelection = useCallback(() => {
-    setClickedPlumePoint(null)
     clearTopPolygonsFill('watershed')
     clearSelectedPlumeWatershedStats()
-  }, [clearTopPolygonsFill, clearSelectedPlumeWatershedStats])
+    onDispersalPointChange(null)
+  }, [clearTopPolygonsFill, clearSelectedPlumeWatershedStats, onDispersalPointChange])
 
-  const setSelectedFeature = useSelectedFeatureStore((s) => s.setSelectedFeature)
+  const clearWatershedSelection = useCallback(() => {
+    clearSelectedFeature()
+    onWatershedChange(null)
+  }, [clearSelectedFeature, onWatershedChange])
+
   const handleFeatureSelect = useCallback(
     (
       feature: MapGeoJSONFeature | null,
@@ -449,23 +511,6 @@ export default function BaseMap({
     }
   }, [])
 
-  const watershedIndex = useMemo(
-    () => mapLayers.findIndex((l) => l.layerId === 'watershed'),
-    [mapLayers],
-  )
-  const watershedLayer = watershedIndex >= 0 ? mapLayers[watershedIndex] : undefined
-
-  useEffect(() => {
-    const map = mapRef.current?.getMap()
-
-    const jumpOptions = {
-      center: selectedRegion.centerCoord,
-      zoom: selectedRegion.zoomLevel,
-      bearing: 0,
-    }
-    map?.jumpTo(jumpOptions)
-  }, [selectedRegion])
-
   useEffect(() => {
     if (!isMapLoaded) {
       return
@@ -491,7 +536,6 @@ export default function BaseMap({
 
   // When selectedFeature is cleared externally (e.g., dropdown region change),
   // remove the visual highlight from the map.
-  const selectedFeature = useSelectedFeatureStore((s) => s.selectedFeature)
   useEffect(() => {
     if (!selectedFeature && polygonClickRef.current && isMapLoaded) {
       const map = mapRef.current?.getMap()
@@ -548,26 +592,29 @@ export default function BaseMap({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isMapLoaded, initialWatershedId, watershedLayer, hasExplicitViewState])
 
-  const benthicFillColors = useMapStore((s) => s.benthicMapSubLayerColors)
-  const benthicSubLayerFillExpression = useMemo(
-    () => [
-      'case',
-      ['==', ['get', 'class_name'], 'Coral/Algae'],
-      benthicFillColors['coral_algae'],
-      ['==', ['get', 'class_name'], 'Benthic Microalgae'],
-      benthicFillColors['microalgal_mats'],
-      ['==', ['get', 'class_name'], 'Rock'],
-      benthicFillColors['rock'],
-      ['==', ['get', 'class_name'], 'Rubble'],
-      benthicFillColors['rubble'],
-      ['==', ['get', 'class_name'], 'Sand'],
-      benthicFillColors['sand'],
-      ['==', ['get', 'class_name'], 'Seagrass'],
-      benthicFillColors['seagrass'],
-      transparent, // Default / other
-    ],
-    [benthicFillColors],
-  )
+  // Plume restoration from URL
+  useEffect(() => {
+    if (!isMapLoaded || !initialDispersalPoint || !watershedLayer) {
+      return
+    }
+
+    const map = mapRef.current?.getMap()
+    if (!map) {
+      return
+    }
+
+    void (async () => {
+      const allYearStats = await getAllYearZonalStats(initialDispersalPoint)
+      applyPlumeStats({
+        map,
+        watershedLayer,
+        point: initialDispersalPoint,
+        allYearStats,
+        selectedYear,
+        setBreadcrumb,
+      })
+    })()
+  }, [isMapLoaded, initialDispersalPoint, watershedLayer, setBreadcrumb, selectedYear])
 
   const handleMapLoad = () => {
     setIsMapLoaded(true)
@@ -601,8 +648,9 @@ export default function BaseMap({
         map,
         watershedLayer,
         selectedYear,
-        setClickedPlumePoint,
         setBreadcrumb,
+        onDispersalPointChange,
+        clearWatershedSelection,
         requestIdRef: plumeRequestIdRef,
       })
 
@@ -646,12 +694,8 @@ export default function BaseMap({
             <NavigationControl position="bottom-right" showCompass={false} />
           </>
         )}
-        {clickedPlumePoint && (
-          <Marker
-            longitude={clickedPlumePoint.lng}
-            latitude={clickedPlumePoint.lat}
-            anchor="center"
-          >
+        {dispersalPoint && (
+          <Marker longitude={dispersalPoint.lng} latitude={dispersalPoint.lat} anchor="center">
             <div className={styles['plume-marker']} />
           </Marker>
         )}

--- a/src/components/BaseMap/BaseMap.tsx
+++ b/src/components/BaseMap/BaseMap.tsx
@@ -49,7 +49,6 @@ import { useTranslation } from 'react-i18next'
 import {
   mapFitBoundsDesktopConfig,
   mapFitBoundsMobileConfig,
-  oceanClickMarkerColor,
   polygonOutlineHoverColor,
   polygonOutlineSelectColor,
 } from '../../constants'
@@ -653,16 +652,7 @@ export default function BaseMap({
             latitude={clickedPlumePoint.lat}
             anchor="center"
           >
-            <div
-              style={{
-                width: 15,
-                height: 15,
-                border: `2px solid ${oceanClickMarkerColor}`,
-                borderRadius: 5,
-                background: 'transparent',
-                pointerEvents: 'none',
-              }}
-            />
+            <div className={styles['plume-marker']} />
           </Marker>
         )}
         {/* Watershed always rendered first so other layers can reference it via beforeId */}
@@ -771,15 +761,7 @@ export default function BaseMap({
         action={
           <button
             type="button"
-            style={{
-              background: 'none',
-              border: 'none',
-              color: 'white',
-              textDecoration: 'underline',
-              cursor: 'pointer',
-              fontWeight: 'normal',
-              paddingRight: '10px',
-            }}
+            className={styles['snackbar-reload-button']}
             onClick={() => window.location.reload()}
           >
             {t('buttons.reload_page')}

--- a/src/components/BaseMap/BaseMap.tsx
+++ b/src/components/BaseMap/BaseMap.tsx
@@ -415,6 +415,7 @@ export default function BaseMap({
   )
 
   const clearPlumeSelection = useCallback(() => {
+    plumeRequestIdRef.current += 1 // Prevent a stale plume response from applying if the fetch resolves after this selection is cleared.
     clearTopPolygonsFill('watershed')
     clearSelectedPlumeWatershedStats()
     onDispersalPointChange(null)

--- a/src/components/BaseMap/BaseMap.tsx
+++ b/src/components/BaseMap/BaseMap.tsx
@@ -24,6 +24,7 @@ import maplibregl, {
   ErrorEvent as MapErrorEvent,
   LngLatBounds,
   MapGeoJSONFeature,
+  LngLat,
 } from 'maplibre-gl'
 import * as pmtiles from 'pmtiles'
 import { cogProtocol } from '@geomatico/maplibre-cog-protocol'
@@ -99,6 +100,7 @@ const handleMapClick = async (
   map,
   selectedYear: number,
   setClickedPlumePoint: (point: { lng: number; lat: number } | null) => void,
+  setBreadcrumb: Dispatch<SetStateAction<RegionOption[]>>,
 ) => {
   const { setTopPolygonsFill } = useMapStore.getState()
   const { setSelectedPlumeWatershedStats } = useSelectedFeatureStore.getState()
@@ -112,6 +114,17 @@ const handleMapClick = async (
 
   clearSelectedFeature()
   setClickedPlumePoint({ lng: e.lngLat.lng, lat: e.lngLat.lat })
+
+  const subRegionWithUpdatedConfig: RegionOption = {
+    id: 'plume',
+    regionType: 'plume',
+    label: 'Plumes',
+    centerCoord: new LngLat(e.lngLat.lng, e.lngLat.lat),
+    zoomLevel: map.getZoom(),
+    grouping: 3,
+  }
+  const updatedRegions: RegionOption[] = [defaultGlobalRegionOption, subRegionWithUpdatedConfig]
+  setBreadcrumb(updatedRegions)
 
   const currentAllYearZonalStats = await getAllYearZonalStats(e.lngLat)
   setSelectedPlumeWatershedStats(currentAllYearZonalStats)
@@ -438,7 +451,7 @@ export default function BaseMap({
       return
     }
 
-    const onClick = (e) => handleMapClick(e, map, selectedYear, setClickedPlumePoint)
+    const onClick = (e) => handleMapClick(e, map, selectedYear, setClickedPlumePoint, setBreadcrumb)
     const onError = (e) => handleError(e, setLayerErrors)
     const onSourceData = (e) => handleSourceData(e, setLayerErrors)
 
@@ -452,7 +465,7 @@ export default function BaseMap({
       map.off('error', onError)
       map.off('sourcedata', onSourceData)
     }
-  }, [isMapLoaded, selectedYear])
+  }, [isMapLoaded, selectedYear, setBreadcrumb])
 
   const watershedIndex = useMemo(
     () => mapLayers.findIndex((l) => l.layerId === 'watershed'),

--- a/src/components/BaseMap/BaseMap.tsx
+++ b/src/components/BaseMap/BaseMap.tsx
@@ -25,6 +25,7 @@ import maplibregl, {
   LngLatBounds,
   MapGeoJSONFeature,
   LngLat,
+  MapMouseEvent,
 } from 'maplibre-gl'
 import * as pmtiles from 'pmtiles'
 import { cogProtocol } from '@geomatico/maplibre-cog-protocol'
@@ -62,6 +63,20 @@ const plumeCrosshairCursor = `url("${crosshairCursorUrl}") 10 10, crosshair`
 
 const getRegionByLabel = (regionLabel) => regionOptions.find((opt) => opt.label === regionLabel)
 
+const buildBreadcrumb = (
+  featureProperties: Record<string, unknown> | null | undefined,
+  subRegion: RegionOption,
+): { breadcrumb: RegionOption[]; addtlRegion: RegionOption | undefined } => {
+  const countryOrRegion = featureProperties?.TERRITORY1 || featureProperties?.REALM
+  const addtlRegion = getRegionByLabel(countryOrRegion)
+  const breadcrumb: RegionOption[] = [defaultGlobalRegionOption]
+  if (addtlRegion) {
+    breadcrumb.push(addtlRegion)
+  }
+  breadcrumb.push(subRegion)
+  return { breadcrumb, addtlRegion }
+}
+
 const handleSourceData = (
   e: SourceDataEvent,
   setLayerErrors: Dispatch<SetStateAction<Record<string, string>>>,
@@ -95,44 +110,28 @@ const handleError = (
   }))
 }
 
-const handleMapClick = async (
-  e,
-  map,
-  selectedYear: number,
-  setClickedPlumePoint: (point: { lng: number; lat: number } | null) => void,
-  setBreadcrumb: Dispatch<SetStateAction<RegionOption[]>>,
-) => {
+interface HandleMapClickParamProps {
+  map: maplibregl.Map
+  watershedLayer: LayerInfo
+  selectedYear: number
+  setClickedPlumePoint: (point: { lng: number; lat: number } | null) => void
+  setBreadcrumb: Dispatch<SetStateAction<RegionOption[]>>
+}
+
+const handleMapClick = async (e: MapMouseEvent, clickParams: HandleMapClickParamProps) => {
+  const { map, watershedLayer, selectedYear, setClickedPlumePoint, setBreadcrumb } = clickParams
   const { setTopPolygonsFill } = useMapStore.getState()
   const { setSelectedPlumeWatershedStats } = useSelectedFeatureStore.getState()
   const { clearSelectedFeature } = useSelectedFeatureStore.getState()
 
-  const plumeFeatures = map.queryRenderedFeatures(e.point, { layers: ['plumes'] })
-
-  if (plumeFeatures.length === 0) {
-    return
-  }
-
   clearSelectedFeature()
   setClickedPlumePoint({ lng: e.lngLat.lng, lat: e.lngLat.lat })
-
-  const subRegionWithUpdatedConfig: RegionOption = {
-    id: 'plume',
-    regionType: 'plume',
-    label: 'Plumes',
-    centerCoord: new LngLat(e.lngLat.lng, e.lngLat.lat),
-    zoomLevel: map.getZoom(),
-    grouping: 3,
-  }
-  const updatedRegions: RegionOption[] = [defaultGlobalRegionOption, subRegionWithUpdatedConfig]
-  setBreadcrumb(updatedRegions)
 
   const currentAllYearZonalStats = await getAllYearZonalStats(e.lngLat)
   setSelectedPlumeWatershedStats(currentAllYearZonalStats)
 
   const currentYearZonalStats = currentAllYearZonalStats[selectedYear]
   const topContributingWatershedIds: number[] = []
-  // TODO: example ids used temporarily - actual zonal stats ids are not yet synced with watershed polygon ids
-  const exampleTopWatershedIds = [974529, 977314, 977908]
 
   for (let i = 2; i < 5; i++) {
     const watershedId = currentYearZonalStats[`band_${i}`]?.majority
@@ -141,6 +140,23 @@ const handleMapClick = async (
     }
   }
 
+  // TODO: replace with topContributingWatershedIds when real stats are available
+  const exampleTopWatershedIds = [974529, 977314, 977908]
+
+  const watershedFeatures = map.querySourceFeatures(watershedLayer.sourceId, {
+    sourceLayer: watershedLayer.sourceFileName,
+    filter: ['in', ['get', 'watershed_id'], ['literal', exampleTopWatershedIds]],
+  })
+  const { breadcrumb } = buildBreadcrumb(watershedFeatures[0]?.properties, {
+    id: 'plume',
+    regionType: 'plume',
+    label: 'Plume',
+    centerCoord: new LngLat(e.lngLat.lng, e.lngLat.lat),
+    zoomLevel: map.getZoom(),
+    grouping: 3,
+  })
+
+  setBreadcrumb(breadcrumb)
   setTopPolygonsFill('watershed', exampleTopWatershedIds) //TODO: replace with topContributingWatershedIds when real stats are available
 }
 
@@ -343,28 +359,18 @@ export default function BaseMap({
         const map = mapRef.current?.getMap()
 
         if (map) {
-          // TODO: for plume, use different property lookup
-          const countryOrRegion = feature.properties.TERRITORY1 || feature.properties.REALM
-
-          const addtlRegion: RegionOption | undefined = getRegionByLabel(countryOrRegion)
-          const subRegionWithUpdatedConfig: RegionOption = {
+          // Breadcrumb: Global > [Country] > Watershed
+          // Country is omitted if it can't be determined from the feature
+          const { breadcrumb, addtlRegion } = buildBreadcrumb(feature.properties, {
             id: 'watershed',
             regionType: 'watershed',
             label: 'Watershed',
             centerCoord: bounds.getCenter(),
             zoomLevel: map.getZoom(),
             grouping: 3,
-          }
+          })
 
-          // Breadcrumb: Global > [Country] > Watershed
-          // Country is omitted if it can't be determined from the feature
-          const updatedRegions: RegionOption[] = [defaultGlobalRegionOption]
-          if (addtlRegion) {
-            updatedRegions.push(addtlRegion)
-          }
-          updatedRegions.push(subRegionWithUpdatedConfig)
-
-          setBreadcrumb(updatedRegions)
+          setBreadcrumb(breadcrumb)
           if (addtlRegion) {
             onRegionChange(addtlRegion)
           }
@@ -430,6 +436,12 @@ export default function BaseMap({
     }
   }, [])
 
+  const watershedIndex = useMemo(
+    () => mapLayers.findIndex((l) => l.layerId === 'watershed'),
+    [mapLayers],
+  )
+  const watershedLayer = watershedIndex >= 0 ? mapLayers[watershedIndex] : undefined
+
   useEffect(() => {
     const map = mapRef.current?.getMap()
 
@@ -451,27 +463,18 @@ export default function BaseMap({
       return
     }
 
-    const onClick = (e) => handleMapClick(e, map, selectedYear, setClickedPlumePoint, setBreadcrumb)
     const onError = (e) => handleError(e, setLayerErrors)
     const onSourceData = (e) => handleSourceData(e, setLayerErrors)
 
-    map.on('click', onClick)
     map.on('error', onError)
     map.on('sourcedata', onSourceData)
 
     // eslint-disable-next-line consistent-return
     return () => {
-      map.off('click', onClick)
       map.off('error', onError)
       map.off('sourcedata', onSourceData)
     }
-  }, [isMapLoaded, selectedYear, setBreadcrumb])
-
-  const watershedIndex = useMemo(
-    () => mapLayers.findIndex((l) => l.layerId === 'watershed'),
-    [mapLayers],
-  )
-  const watershedLayer = watershedIndex >= 0 ? mapLayers[watershedIndex] : undefined
+  }, [isMapLoaded])
 
   // When selectedFeature is cleared externally (e.g., dropdown region change),
   // remove the visual highlight from the map.
@@ -573,17 +576,26 @@ export default function BaseMap({
       polygonClickBoundRef.current = null
     }
 
-    const hoverBound = (e) => {
+    const onWatershedHover = (e) => {
       polygonHoverHandler(map, e, watershedLayer)
     }
-    const clickBound = (e) => {
+    const onWatershedClick = (e) => {
       polygonClickHandler(map, e, watershedLayer)
     }
 
-    polygonHoverBoundRef.current = hoverBound
-    polygonClickBoundRef.current = clickBound
-    map.on('mousemove', 'watershed', hoverBound)
-    map.on('click', 'watershed', clickBound)
+    const onPlumeClick = (e) =>
+      handleMapClick(e, {
+        map,
+        watershedLayer,
+        selectedYear,
+        setClickedPlumePoint,
+        setBreadcrumb,
+      })
+
+    polygonHoverBoundRef.current = onWatershedHover
+    polygonClickBoundRef.current = onWatershedClick
+    map.on('click', 'watershed', onWatershedClick)
+    map.on('mousemove', 'watershed', onWatershedHover)
     map.on('mouseenter', 'watershed', () => {
       map.getCanvas().style.cursor = 'pointer'
     })
@@ -592,6 +604,7 @@ export default function BaseMap({
       clearPolygonHover(map, polygonHoverRef, watershedLayer)
     })
 
+    map.on('click', 'plumes', onPlumeClick)
     map.on('mousemove', 'plumes', () => {
       map.getCanvas().style.cursor = plumeCrosshairCursor
     })

--- a/src/components/BaseMap/BaseMap.tsx
+++ b/src/components/BaseMap/BaseMap.tsx
@@ -603,6 +603,15 @@ export default function BaseMap({
       return
     }
 
+    // Validate the dispersal point falls within the plume layer.
+    // If the param was manually edited or the data changed, clear it.
+    const pixel = map.project([initialDispersalPoint.lng, initialDispersalPoint.lat])
+    const plumeFeatures = map.queryRenderedFeatures(pixel, { layers: ['plumes'] })
+    if (plumeFeatures.length === 0) {
+      onDispersalPointChange(null)
+      return
+    }
+
     void (async () => {
       const allYearStats = await getAllYearZonalStats(initialDispersalPoint)
       applyPlumeStats({
@@ -614,6 +623,9 @@ export default function BaseMap({
         setBreadcrumb,
       })
     })()
+    // onDispersalPointChange intentionally omitted — this effect is for initial restoration only.
+    // initialDispersalPoint is stable (captured once at mount) so this effect only runs once when the map loads.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isMapLoaded, initialDispersalPoint, watershedLayer, setBreadcrumb, selectedYear])
 
   const handleMapLoad = () => {

--- a/src/components/BaseMap/BaseMap.tsx
+++ b/src/components/BaseMap/BaseMap.tsx
@@ -367,8 +367,8 @@ export default function BaseMap({
 
   const polygonHoverHandler = useMemo(() => createPolygonHoverHandler(polygonHoverRef), [])
   const polygonClickHandler = useMemo(
-    () => createPolygonClickHandler(polygonClickRef, handleFeatureSelect),
-    [handleFeatureSelect],
+    () => createPolygonClickHandler(polygonClickRef, handleFeatureSelect, setClickedPlumePoint),
+    [handleFeatureSelect, setClickedPlumePoint],
   )
 
   const handleMoveEnd = useCallback(

--- a/src/components/BaseMap/BaseMap.tsx
+++ b/src/components/BaseMap/BaseMap.tsx
@@ -38,7 +38,6 @@ import {
   createPolygonHoverHandler,
   querySourceFeatureWhenReady,
   setPolygonSelect,
-  prepareZonalStatsCall,
   getAllYearZonalStats,
 } from '../../utils/mapUtils'
 import { SourceDataEvent } from '../../types/MapLayerErrorTypes'
@@ -52,7 +51,7 @@ import {
   polygonOutlineSelectColor,
 } from '../../constants'
 import { useSelectedFeatureStore } from '../../stores/selectedFeatureStore'
-import { LayerInfo, ZonalStatsBand } from '../../types/MapDataTypes'
+import { LayerInfo } from '../../types/MapDataTypes'
 import { useMapStore } from '../../stores/mapStore'
 import { transparent } from '../../data/mapData'
 import { defaultGlobalRegionOption, regionOptions } from '../../data/regionData'
@@ -122,9 +121,9 @@ const handleMapClick = async (
   // TODO: example ids used temporarily - actual zonal stats ids are not yet synced with watershed polygon ids
   const exampleTopWatershedIds = [974529, 977314, 977908]
 
-  for (let i = 2; i <= 5; i++) {
-    if (topContributingWatershedIds.indexOf(currentYearZonalStats[`band_${i}`].majority) < 0) {
-      topContributingWatershedIds.push(currentYearZonalStats[`band_${i}`].majority)
+  for (let i = 2; i < 5; i++) {
+    if (topContributingWatershedIds.indexOf(currentYearZonalStats[`band_${i}`]?.majority) < 0) {
+      topContributingWatershedIds.push(currentYearZonalStats[`band_${i}`]?.majority)
     }
   }
 
@@ -436,7 +435,7 @@ export default function BaseMap({
       map.off('error', onError)
       map.off('sourcedata', onSourceData)
     }
-  }, [isMapLoaded])
+  }, [isMapLoaded, selectedYear])
 
   const watershedIndex = useMemo(
     () => mapLayers.findIndex((l) => l.layerId === 'watershed'),

--- a/src/components/BaseMap/BaseMap.tsx
+++ b/src/components/BaseMap/BaseMap.tsx
@@ -295,6 +295,10 @@ export default function BaseMap({
   const mapRef = useRef<MapRef | null>(useMapStore((s) => s.mapReference))
   const setMapRef = useMapStore((s) => s.setMapRef)
   const benthicFillColors = useMapStore((s) => s.benthicMapSubLayerColors)
+  const clearTopPolygonsFill = useMapStore((s) => s.clearTopPolygonsFill)
+  const clearSelectedPlumeWatershedStats = useSelectedFeatureStore(
+    (s) => s.clearSelectedPlumeWatershedStats,
+  )
 
   const [layerErrors, setLayerErrors] = useState<Record<string, string>>({})
   const polygonHoverRef = useRef<string | number | null>(null)
@@ -315,6 +319,9 @@ export default function BaseMap({
       options?: { skipFitBounds?: boolean },
     ) => {
       setSelectedFeature(feature)
+      setClickedPlumePoint(null)
+      clearTopPolygonsFill('watershed')
+      clearSelectedPlumeWatershedStats()
 
       if (feature && bounds) {
         const map = mapRef.current?.getMap()
@@ -362,13 +369,21 @@ export default function BaseMap({
         }
       }
     },
-    [isDesktopWidth, setBreadcrumb, setSelectedFeature, onRegionChange, onWatershedChange],
+    [
+      isDesktopWidth,
+      setBreadcrumb,
+      setSelectedFeature,
+      onRegionChange,
+      onWatershedChange,
+      clearSelectedPlumeWatershedStats,
+      clearTopPolygonsFill,
+    ],
   )
 
   const polygonHoverHandler = useMemo(() => createPolygonHoverHandler(polygonHoverRef), [])
   const polygonClickHandler = useMemo(
-    () => createPolygonClickHandler(polygonClickRef, handleFeatureSelect, setClickedPlumePoint),
-    [handleFeatureSelect, setClickedPlumePoint],
+    () => createPolygonClickHandler(polygonClickRef, handleFeatureSelect),
+    [handleFeatureSelect],
   )
 
   const handleMoveEnd = useCallback(

--- a/src/components/BaseMap/BaseMap.tsx
+++ b/src/components/BaseMap/BaseMap.tsx
@@ -294,11 +294,6 @@ export default function BaseMap({
   } | null>(null)
   const mapRef = useRef<MapRef | null>(useMapStore((s) => s.mapReference))
   const setMapRef = useMapStore((s) => s.setMapRef)
-  const benthicFillColors = useMapStore((s) => s.benthicMapSubLayerColors)
-  const clearTopPolygonsFill = useMapStore((s) => s.clearTopPolygonsFill)
-  const clearSelectedPlumeWatershedStats = useSelectedFeatureStore(
-    (s) => s.clearSelectedPlumeWatershedStats,
-  )
 
   const [layerErrors, setLayerErrors] = useState<Record<string, string>>({})
   const polygonHoverRef = useRef<string | number | null>(null)
@@ -310,8 +305,18 @@ export default function BaseMap({
     return Object.keys(layerErrors).length > 0
   }, [layerErrors])
 
-  const setSelectedFeature = useSelectedFeatureStore((s) => s.setSelectedFeature)
+  const clearTopPolygonsFill = useMapStore((s) => s.clearTopPolygonsFill)
+  const clearSelectedPlumeWatershedStats = useSelectedFeatureStore(
+    (s) => s.clearSelectedPlumeWatershedStats,
+  )
 
+  const clearPlumeSelection = useCallback(() => {
+    setClickedPlumePoint(null)
+    clearTopPolygonsFill('watershed')
+    clearSelectedPlumeWatershedStats()
+  }, [clearTopPolygonsFill, clearSelectedPlumeWatershedStats])
+
+  const setSelectedFeature = useSelectedFeatureStore((s) => s.setSelectedFeature)
   const handleFeatureSelect = useCallback(
     (
       feature: MapGeoJSONFeature | null,
@@ -319,9 +324,7 @@ export default function BaseMap({
       options?: { skipFitBounds?: boolean },
     ) => {
       setSelectedFeature(feature)
-      setClickedPlumePoint(null)
-      clearTopPolygonsFill('watershed')
-      clearSelectedPlumeWatershedStats()
+      clearPlumeSelection()
 
       if (feature && bounds) {
         const map = mapRef.current?.getMap()
@@ -375,8 +378,7 @@ export default function BaseMap({
       setSelectedFeature,
       onRegionChange,
       onWatershedChange,
-      clearSelectedPlumeWatershedStats,
-      clearTopPolygonsFill,
+      clearPlumeSelection,
     ],
   )
 
@@ -517,6 +519,7 @@ export default function BaseMap({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isMapLoaded, initialWatershedId, watershedLayer, hasExplicitViewState])
 
+  const benthicFillColors = useMapStore((s) => s.benthicMapSubLayerColors)
   const benthicSubLayerFillExpression = useMemo(
     () => [
       'case',

--- a/src/components/MapContainer/MapContainer.tsx
+++ b/src/components/MapContainer/MapContainer.tsx
@@ -49,7 +49,6 @@ export default function MapContainer() {
   const shouldSyncLayersParam = layersParam !== normalizedLayersParam
 
   const watershedParam = searchParams.get('watershed')
-  // const dispersalPoint = getValidDispersalPoint(searchParams.get('dispersal-point'))
   const dispersalPointParam = searchParams.get('dispersal-point')
   const dispersalPoint = useMemo(
     () => getValidDispersalPoint(dispersalPointParam),

--- a/src/components/MapContainer/MapContainer.tsx
+++ b/src/components/MapContainer/MapContainer.tsx
@@ -49,7 +49,12 @@ export default function MapContainer() {
   const shouldSyncLayersParam = layersParam !== normalizedLayersParam
 
   const watershedParam = searchParams.get('watershed')
-  const dispersalPoint = getValidDispersalPoint(searchParams.get('dispersal-point'))
+  // const dispersalPoint = getValidDispersalPoint(searchParams.get('dispersal-point'))
+  const dispersalPointParam = searchParams.get('dispersal-point')
+  const dispersalPoint = useMemo(
+    () => getValidDispersalPoint(dispersalPointParam),
+    [dispersalPointParam],
+  )
   const { lat, lng } = getValidLatLng(searchParams.get('lat'), searchParams.get('lng'))
   const zoom = getValidZoom(searchParams.get('zoom'))
   const hasExplicitViewState = lat !== null && lng !== null && zoom !== null

--- a/src/components/MapContainer/MapContainer.tsx
+++ b/src/components/MapContainer/MapContainer.tsx
@@ -280,6 +280,7 @@ export default function MapContainer() {
         onRegionChange={handleRegionChange}
         onWatershedChange={handleWatershedChange}
         initialWatershedId={initialWatershedId}
+        selectedYear={selectedYear}
         hasExplicitViewState={hasExplicitViewState}
         setBreadcrumb={setBreadcrumb}
         initialViewState={{

--- a/src/components/MapContainer/MapContainer.tsx
+++ b/src/components/MapContainer/MapContainer.tsx
@@ -16,13 +16,23 @@ import {
   getValidRegion,
   getValidWatershed,
   getValidZoom,
+  getValidDispersalPoint,
 } from '../../utils/routeUtils'
 import { useMapStore } from '../../stores/mapStore'
 import { useSelectedFeatureStore } from '../../stores/selectedFeatureStore'
 import { defaultGlobalRegionOption } from '../../data/regionData'
 
 export default function MapContainer() {
+  const toggleSedExportSubLayerFills = useMapStore((state) => state.toggleSedExportSubLayerFills)
+  const turnOffSedExportSubLayerFills = useMapStore((state) => state.turnOffSedExportSubLayerFills)
+  const clearTopPolygonsFill = useMapStore((s) => s.clearTopPolygonsFill)
+  const clearSelectedFeature = useSelectedFeatureStore((s) => s.clearSelectedFeature)
+  const clearSelectedPlumeWatershedStats = useSelectedFeatureStore(
+    (s) => s.clearSelectedPlumeWatershedStats,
+  )
+
   const [searchParams, setSearchParams] = useSearchParams()
+
   const year = searchParams.get('year')
   const selectedYear = getValidYear(year)
   const normalizedYearParam = selectedYear.toString()
@@ -38,45 +48,27 @@ export default function MapContainer() {
   const normalizedLayersParam = selectedLayers.length > 0 ? selectedLayers.join(',') : 'none'
   const shouldSyncLayersParam = layersParam !== normalizedLayersParam
 
+  const watershedParam = searchParams.get('watershed')
+  const dispersalPoint = getValidDispersalPoint(searchParams.get('dispersal-point'))
+  const { lat, lng } = getValidLatLng(searchParams.get('lat'), searchParams.get('lng'))
+  const zoom = getValidZoom(searchParams.get('zoom'))
+  const hasExplicitViewState = lat !== null && lng !== null && zoom !== null
+
   // Captured once at mount — only used for initial restoration on page load.
   // Clicks update the URL via handleWatershedChange but don't re-trigger restoration.
   const [initialWatershedId] = useState(() => getValidWatershed(searchParams.get('watershed')))
-
-  // TODO: Handle dispersal-point URL param (C152)
-
-  const { lat, lng } = getValidLatLng(searchParams.get('lat'), searchParams.get('lng'))
-  const zoom = getValidZoom(searchParams.get('zoom'))
-
-  const hasExplicitViewState = lat !== null && lng !== null && zoom !== null
+  const [initialDispersalPoint] = useState(() =>
+    getValidDispersalPoint(searchParams.get('dispersal-point')),
+  )
 
   const [mapLayers, setMapLayers] = useState<LayerInfo[]>(layers)
   const [subSedLayerValue, setSubLayerValue] = useState<'pixel' | 'watershed'>('pixel')
-
-  const [selectedRegion, setSelectedRegion] = useState<RegionOption>(defaultGlobalRegionOption)
+  const [selectedRegion, setSelectedRegion] = useState<RegionOption>(initialRegion)
   const [breadcrumb, setBreadcrumb] = useState<RegionOption[]>(
     initialRegion.grouping > 0 ? [defaultGlobalRegionOption, initialRegion] : [initialRegion],
   )
 
-  const toggleSedExportSubLayerFills = useMapStore((state) => state.toggleSedExportSubLayerFills)
-  const turnOffSedExportSubLayerFills = useMapStore((state) => state.turnOffSedExportSubLayerFills)
-  const clearSelectedFeature = useSelectedFeatureStore((s) => s.clearSelectedFeature)
   const latestSearchParamsRef = useRef(new URLSearchParams(searchParams))
-
-  useEffect(() => {
-    latestSearchParamsRef.current = new URLSearchParams(searchParams)
-  }, [searchParams])
-
-  const updateSearchParams = useCallback(
-    (
-      updater: (prevSearchParams: URLSearchParams) => URLSearchParams,
-      navigateOptions?: { replace?: boolean },
-    ) => {
-      const nextSearchParams = updater(new URLSearchParams(latestSearchParamsRef.current))
-      latestSearchParamsRef.current = new URLSearchParams(nextSearchParams)
-      setSearchParams(nextSearchParams, navigateOptions)
-    },
-    [setSearchParams],
-  )
 
   const urlSyncedMapLayers = useMemo(
     () =>
@@ -92,6 +84,22 @@ export default function MapContainer() {
       }),
     [mapLayers, selectedLayers, selectedYear],
   )
+
+  const updateSearchParams = useCallback(
+    (
+      updater: (prevSearchParams: URLSearchParams) => URLSearchParams,
+      navigateOptions?: { replace?: boolean },
+    ) => {
+      const nextSearchParams = updater(new URLSearchParams(latestSearchParamsRef.current))
+      latestSearchParamsRef.current = new URLSearchParams(nextSearchParams)
+      setSearchParams(nextSearchParams, navigateOptions)
+    },
+    [setSearchParams],
+  )
+
+  useEffect(() => {
+    latestSearchParamsRef.current = new URLSearchParams(searchParams)
+  }, [searchParams])
 
   useEffect(() => {
     if (!shouldSyncYearParam && !shouldSyncRegionParam && !shouldSyncLayersParam) {
@@ -117,8 +125,6 @@ export default function MapContainer() {
     shouldSyncRegionParam,
     shouldSyncLayersParam,
   ])
-
-  const watershedParam = searchParams.get('watershed')
 
   useEffect(() => {
     setSelectedRegion(initialRegion)
@@ -161,15 +167,51 @@ export default function MapContainer() {
     [updateSearchParams],
   )
 
+  const handleDispersalPointChange = useCallback(
+    (newDispersalPoint: { lat: number; lng: number } | null) => {
+      updateSearchParams(
+        (prev) => {
+          const nextSearchParams = new URLSearchParams(prev)
+          if (newDispersalPoint) {
+            nextSearchParams.set(
+              'dispersal-point',
+              `${newDispersalPoint.lat.toFixed(6)},${newDispersalPoint.lng.toFixed(6)}`,
+            )
+          } else {
+            nextSearchParams.delete('dispersal-point')
+          }
+          return nextSearchParams
+        },
+        { replace: true },
+      )
+    },
+    [updateSearchParams],
+  )
+
   // Used by the region dropdown and breadcrumb navigation.
-  // Clears watershed state since the user is navigating to a different scope.
+  // Clears watershed and plume state since the user is navigating to a different scope.
   const handleRegionDropdownChange = useCallback(
     (region: RegionOption) => {
       handleRegionChange(region)
       handleWatershedChange(null)
+      handleDispersalPointChange(null)
       clearSelectedFeature()
+      clearSelectedPlumeWatershedStats()
+      clearTopPolygonsFill('watershed')
+      useMapStore.getState().mapReference?.getMap()?.jumpTo({
+        center: region.centerCoord,
+        zoom: region.zoomLevel,
+        bearing: 0,
+      })
     },
-    [handleRegionChange, handleWatershedChange, clearSelectedFeature],
+    [
+      handleRegionChange,
+      handleWatershedChange,
+      handleDispersalPointChange,
+      clearSelectedFeature,
+      clearSelectedPlumeWatershedStats,
+      clearTopPolygonsFill,
+    ],
   )
 
   const handleYearChange = useCallback(
@@ -276,10 +318,12 @@ export default function MapContainer() {
       <BaseMap
         mapLayers={urlSyncedMapLayers}
         sedExportSubLayerValue={subSedLayerValue}
-        selectedRegion={selectedRegion}
+        dispersalPoint={dispersalPoint}
         onRegionChange={handleRegionChange}
         onWatershedChange={handleWatershedChange}
+        onDispersalPointChange={handleDispersalPointChange}
         initialWatershedId={initialWatershedId}
+        initialDispersalPoint={initialDispersalPoint}
         selectedYear={selectedYear}
         hasExplicitViewState={hasExplicitViewState}
         setBreadcrumb={setBreadcrumb}

--- a/src/components/TrendsDrawer/TrendsDrawer.tsx
+++ b/src/components/TrendsDrawer/TrendsDrawer.tsx
@@ -11,14 +11,17 @@ import { ChartProperties, ChartSeriesName } from '../../types/ChartDataTypes'
 import { tempGlobalChartSeriesData } from '../../data/tempGlobalChartSeriesData'
 import { SelectedFeatureContext } from '../../contexts/SelectedFeatureContext'
 import { MapGeoJSONFeature } from 'maplibre-gl'
-import {
-  buildChartDataFromProperties,
-  updateChartData,
-  updatePlumeChartData,
-} from '../../utils/chartUtils'
+
 import { useSelectedFeatureStore } from '../../stores/selectedFeatureStore'
 import { chartsByRegionType } from '../../data/chartSeriesData'
 import { fetchBoundaryProperties } from '../../utils/pmtilesUtils'
+import {
+  buildChartDataFromProperties,
+  getDrawerTitle,
+  getEffectiveRegionType,
+  updateChartData,
+  updatePlumeChartData,
+} from '../../utils/chartUtils'
 
 interface TrendsDrawerProps {
   selectedRegion: RegionOption
@@ -42,32 +45,31 @@ export default function TrendsDrawer({ selectedRegion, selectedYear }: TrendsDra
   // Tracks the latest fetch so earlier, slower responses don't overwrite newer ones.
   const requestIdRef = useRef(0)
   useEffect(() => {
+    setIsChartDataLoading(true)
     const { regionType, label } = selectedRegion
 
-    if (regionType === 'global') {
+    if (selectedPlumeWatershedStats) {
+      updatePlumeChartData(selectedPlumeWatershedStats, setChartConfigData)
       setIsChartDataLoading(false)
+      return
+    }
+
+    if (regionType === 'global') {
       setChartConfigData(tempGlobalChartSeriesData)
+      setIsChartDataLoading(false)
       return
     }
 
     // Watershed: selectedFeature from map click takes priority
     if (selectedFeature) {
-      setIsChartDataLoading(true)
       updateChartData(selectedFeature as MapGeoJSONFeature, setChartConfigData)
       setIsChartDataLoading(false)
-      return
-    }
-
-    if (selectedPlumeWatershedStats) {
-      setIsChartDataLoading(false)
-      updatePlumeChartData(selectedPlumeWatershedStats, setChartConfigData)
       return
     }
 
     // Region/country: fetch directly from PMTiles
     if (regionType === 'region' || regionType === 'country') {
       const requestId = ++requestIdRef.current
-      setIsChartDataLoading(true)
 
       fetchBoundaryProperties(regionType, label).then((properties) => {
         if (requestId !== requestIdRef.current) {
@@ -80,25 +82,23 @@ export default function TrendsDrawer({ selectedRegion, selectedYear }: TrendsDra
       return
     }
 
-    setIsChartDataLoading(false)
     setChartConfigData(null)
+    setIsChartDataLoading(false)
   }, [selectedFeature, selectedRegion, selectedPlumeWatershedStats])
 
   // When a feature is selected via map click, derive the region type from
   // its source rather than selectedRegion (which stays as the parent country).
-  const effectiveRegionType =
-    selectedFeature?.source === 'watershed_src' ? 'watershed' : selectedRegion.regionType
+  const effectiveRegionType = getEffectiveRegionType(
+    selectedPlumeWatershedStats,
+    selectedFeature?.source,
+    selectedRegion.regionType,
+  )
+
+  const drawerTitle = getDrawerTitle(effectiveRegionType, selectedRegion.label)
   const allowedCharts = chartsByRegionType[effectiveRegionType]
   const filteredChartData = chartConfigData?.filter((chart) =>
     allowedCharts.includes(chart.chartName as ChartSeriesName),
   )
-
-  let drawerTitle = selectedRegion.label
-  if (effectiveRegionType === 'global') {
-    drawerTitle = 'global_trends'
-  } else if (effectiveRegionType === 'watershed') {
-    drawerTitle = 'watershed_information'
-  }
 
   return (
     <StyledSwipeableDrawer

--- a/src/components/TrendsDrawer/TrendsDrawer.tsx
+++ b/src/components/TrendsDrawer/TrendsDrawer.tsx
@@ -11,7 +11,11 @@ import { ChartProperties, ChartSeriesName } from '../../types/ChartDataTypes'
 import { tempGlobalChartSeriesData } from '../../data/tempGlobalChartSeriesData'
 import { SelectedFeatureContext } from '../../contexts/SelectedFeatureContext'
 import { MapGeoJSONFeature } from 'maplibre-gl'
-import { buildChartDataFromProperties, updateChartData } from '../../utils/chartUtils'
+import {
+  buildChartDataFromProperties,
+  updateChartData,
+  updatePlumeChartData,
+} from '../../utils/chartUtils'
 import { useSelectedFeatureStore } from '../../stores/selectedFeatureStore'
 import { chartsByRegionType } from '../../data/chartSeriesData'
 import { fetchBoundaryProperties } from '../../utils/pmtilesUtils'
@@ -33,6 +37,7 @@ export default function TrendsDrawer({ selectedRegion, selectedYear }: TrendsDra
   const [isChartDataLoading, setIsChartDataLoading] = useState(false)
 
   const selectedFeature = useSelectedFeatureStore((s) => s.selectedFeature)
+  const selectedPlumeWatershedStats = useSelectedFeatureStore((s) => s.selectedPlumeWatershedStats)
 
   // Tracks the latest fetch so earlier, slower responses don't overwrite newer ones.
   const requestIdRef = useRef(0)
@@ -50,6 +55,12 @@ export default function TrendsDrawer({ selectedRegion, selectedYear }: TrendsDra
       setIsChartDataLoading(true)
       updateChartData(selectedFeature as MapGeoJSONFeature, setChartConfigData)
       setIsChartDataLoading(false)
+      return
+    }
+
+    if (selectedPlumeWatershedStats) {
+      setIsChartDataLoading(false)
+      updatePlumeChartData(selectedPlumeWatershedStats, setChartConfigData)
       return
     }
 
@@ -71,7 +82,7 @@ export default function TrendsDrawer({ selectedRegion, selectedYear }: TrendsDra
 
     setIsChartDataLoading(false)
     setChartConfigData(null)
-  }, [selectedFeature, selectedRegion])
+  }, [selectedFeature, selectedRegion, selectedPlumeWatershedStats])
 
   // When a feature is selected via map click, derive the region type from
   // its source rather than selectedRegion (which stays as the parent country).

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -53,6 +53,15 @@ export const BASE_ZONAL_STATS_API =
   'https://api.zonalstats.datamermaid.org/api/v1/zonal-stats/raster'
 export const SEDIMENT_EXPOSURE_2000_URL =
   'https://d2uu99zl9amnvy.cloudfront.net/assets/sediment_exposure/sediment_exposure_2000/data_solomons_sed_exposure_2000.tif'
+/* These below ocean tif not yet available */
+export const SEDIMENT_EXPOSURE_2005_URL =
+  'https://d2uu99zl9amnvy.cloudfront.net/assets/sediment_exposure/sediment_exposure_2005/data_solomons_sed_exposure_2005.tif'
+export const SEDIMENT_EXPOSURE_2010_URL =
+  'https://d2uu99zl9amnvy.cloudfront.net/assets/sediment_exposure/sediment_exposure_2010/data_solomons_sed_exposure_2010.tif'
+export const SEDIMENT_EXPOSURE_2015_URL =
+  'https://d2uu99zl9amnvy.cloudfront.net/assets/sediment_exposure/sediment_exposure_2015/data_solomons_sed_exposure_2015.tif'
+export const SEDIMENT_EXPOSURE_2020_URL =
+  'https://d2uu99zl9amnvy.cloudfront.net/assets/sediment_exposure/sediment_exposure_2020/data_solomons_sed_exposure_2020.tif'
 
 /******MAP FIT BOUNDS******/
 export const mapFitBoundsDesktopConfig = {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -78,5 +78,4 @@ export const mapFitBoundsMobileConfig = {
 export const plumeOutlineColor = '#FFEA46'
 export const polygonOutlineHoverColor = '#00FF01'
 export const polygonOutlineSelectColor = '#0000FF'
-export const oceanClickMarkerColor = '#334BFF'
 export const topContributingWatershedColorFills = ['#FFA600', '#D86D83', '#7A5195']

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,6 +5,7 @@ if (!coralAtlasAppId) {
 }
 
 /******MAP LAYERS******/
+/* Boundary Layers - always on */
 export const REGIONS_PMTILES_URL =
   'https://gpw-coastal-pollution-model-data-public-0001.s3.ap-southeast-2.amazonaws.com/app/regions/regions.pmtiles'
 export const COUNTRIES_PMTILES_URL =
@@ -12,6 +13,7 @@ export const COUNTRIES_PMTILES_URL =
 export const WATERSHED_PMTILES_URL =
   'https://gpw-coastal-pollution-model-data-public-0001.s3.ap-southeast-2.amazonaws.com/app/watersheds/watersheds.pmtiles'
 
+/* Land Use Land Cover Layers */
 export const LULC_2000_URL =
   'https://gpw-coastal-pollution-model-data-public-0001.s3.ap-southeast-2.amazonaws.com/app/global_lulc/lulc_2000_visual.tif'
 export const LULC_2005_URL =
@@ -23,10 +25,12 @@ export const LULC_2015_URL =
 export const LULC_2020_URL =
   'https://gpw-coastal-pollution-model-data-public-0001.s3.ap-southeast-2.amazonaws.com/app/global_lulc/lulc_2020_visual.tif'
 
+/* Benthic Attribute Layers */
 export const ATLAS_BENTHIC_URL = `https://allencoralatlas.org/tiles/benthic/{z}/{x}/{y}?appid=${coralAtlasAppId}`
 export const REEF_EXTENT_URL =
   'https://mermaid.prescient.earth/raster/collections/aca_extent/items/aca_extent/tiles/WebMercatorQuad/{z}/{x}/{y}.png?assets=cog&colormap={"0":[0,0,0,0],"1":[178,8,76,200]}'
 
+/* Sediment Export Layers */
 export const SED_EXPORT_2000_URL =
   'https://gpw-coastal-pollution-model-data-public-0001.s3.ap-southeast-2.amazonaws.com/app/sediment_load/sed_export_load_2000_visual.tif'
 export const SED_EXPORT_2005_URL =
@@ -38,11 +42,17 @@ export const SED_EXPORT_2015_URL =
 export const SED_EXPORT_2020_URL =
   'https://gpw-coastal-pollution-model-data-public-0001.s3.ap-southeast-2.amazonaws.com/app/sediment_load/sed_export_load_2020_visual.tif'
 
+/* Ocean Sediment Dispersal Layers */
 export const SED_DISPERSAL_PMTILES_URL =
   'https://d2uu99zl9amnvy.cloudfront.net/assets/sediment_exposure/sediment_exposure_2000/visual_solomons_plumeshape_2000.pmtiles'
-
 export const SED_DISPERSAL_2000_URL =
   'https://mermaid.prescient.earth/raster/collections/sediment_exposure/items/sediment_exposure_2000/tiles/WebMercatorQuad/{z}/{x}/{y}?rescale=0,1.41&assets=cog&colormap_name=viridis&asset_bidx=cog|1&expression=where(cog_b1>1.41,1.41,cog_b1)'
+
+/* Ocean Sediment Dispersal point stats / Zonal Stats data API */
+export const BASE_ZONAL_STATS_API =
+  'https://api.zonalstats.datamermaid.org/api/v1/zonal-stats/raster'
+export const SEDIMENT_EXPOSURE_2000_URL =
+  'https://d2uu99zl9amnvy.cloudfront.net/assets/sediment_exposure/sediment_exposure_2000/data_solomons_sed_exposure_2000.tif'
 
 /******MAP FIT BOUNDS******/
 export const mapFitBoundsDesktopConfig = {
@@ -59,3 +69,4 @@ export const mapFitBoundsMobileConfig = {
 export const plumeOutlineColor = '#FFEA46'
 export const polygonOutlineHoverColor = '#00FF01'
 export const polygonOutlineSelectColor = '#0000FF'
+export const oceanClickMarkerColor = '#334BFF'

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -79,3 +79,4 @@ export const plumeOutlineColor = '#FFEA46'
 export const polygonOutlineHoverColor = '#00FF01'
 export const polygonOutlineSelectColor = '#0000FF'
 export const oceanClickMarkerColor = '#334BFF'
+export const topContributingWatershedColorFills = ['#FFA600', '#D86D83', '#7A5195']

--- a/src/data/chartSeriesData.ts
+++ b/src/data/chartSeriesData.ts
@@ -51,7 +51,7 @@ export const chartSeriesConfig: ChartSeriesConfig = {
     tracePrefix: '',
     xAxisTitle: 'year',
     yAxisTitle: 'chart_information.sediment_exposure',
-    width: 3,
+    width: 2,
   },
   'charts.contributing_watersheds': {
     barmode: 'stack',

--- a/src/data/chartSeriesData.ts
+++ b/src/data/chartSeriesData.ts
@@ -65,7 +65,7 @@ export const chartSeriesConfig: ChartSeriesConfig = {
     tracePrefix: '',
     xAxisTitle: 'year',
     yAxisTitle: 'chart_information.pollution_contribution',
-    width: 3,
+    width: 2,
   },
 }
 

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -12,15 +12,20 @@
     "land_cover_pct": "Land cover (%)",
     "pollution_contribution": "Pollution contribution (%)",
     "sediment_exposure": "Sediment exposure (tonnes)",
-    "sediment_load": "Sediment load (tonnes)"
+    "sediment_load": "Sediment load (tonnes)",
+    "pollution": "Polution"
   },
+
   "charts": {
     "contributing_watersheds": "Contributing watersheds",
     "ecosystem_extent_exposed": "Ecosystem extent exposed to pollution",
     "land_use_historical": "Land use",
     "no_data_available": "No data available for selected region.",
     "sediment_exposure_historical": "Sediment exposure",
-    "sediment_load_historical": "Sediment load"
+    "sediment_load_historical": "Sediment load",
+    "w1": "W1",
+    "w2": "W2",
+    "w3": "W3"
   },
   "land_types": {
     "bare_ground": "Bare ground",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -12,8 +12,7 @@
     "land_cover_pct": "Land cover (%)",
     "pollution_contribution": "Pollution contribution (%)",
     "sediment_exposure": "Sediment exposure (tonnes)",
-    "sediment_load": "Sediment load (tonnes)",
-    "pollution": "Polution"
+    "sediment_load": "Sediment load (tonnes)"
   },
 
   "charts": {
@@ -62,7 +61,8 @@
     "no_regions_match": "No regions match your search",
     "region": "Region",
     "select_region": "Select region",
-    "watershed": "Watershed"
+    "watershed": "Watershed",
+    "plume": "Plume"
   },
   "agricultural_nutrients": "Agricultural nutrients",
   "all_data": "All data",
@@ -115,5 +115,6 @@
   "year": "Year",
   "toggle_navigation_menu": "Toggle navigation menu",
   "select_year": "Select year",
-  "map_layers_did_not_load": "Some map layers didn't load"
+  "map_layers_did_not_load": "Some map layers didn't load",
+  "ocean_pollution": "Ocean Pollution"
 }

--- a/src/stores/mapStore.ts
+++ b/src/stores/mapStore.ts
@@ -19,6 +19,7 @@ type MapActions = {
   ) => void
   turnOffSedExportSubLayerFills: () => void
   setTopPolygonsFill: (layerId: string, polygonIds: number[], fillColors: string[]) => void
+  clearTopPolygonsFill: (layerId: string) => void
 }
 
 export const useMapStore = create<MapState & MapActions>((set, get) => ({
@@ -97,6 +98,14 @@ export const useMapStore = create<MapState & MapActions>((set, get) => ({
       map.setLayoutProperty('sed_export', 'visibility', 'none')
     }
     map.setPaintProperty('watershed', 'fill-color', transparent)
+  },
+  clearTopPolygonsFill: (layerId) => {
+    const state = get()
+    const map = state.mapReference?.getMap()
+    if (!map) {
+      return
+    }
+    map.setPaintProperty(layerId, 'fill-color', transparent)
   },
   setTopPolygonsFill: (layerId, polygonIds, fillColors) => {
     const state = get()

--- a/src/stores/mapStore.ts
+++ b/src/stores/mapStore.ts
@@ -18,6 +18,7 @@ type MapActions = {
     selectedYear: number,
   ) => void
   turnOffSedExportSubLayerFills: () => void
+  setTopPolygonsFill: (layerId: string, polygonIds: number[], fillColors: string[]) => void
 }
 
 export const useMapStore = create<MapState & MapActions>((set, get) => ({
@@ -96,5 +97,25 @@ export const useMapStore = create<MapState & MapActions>((set, get) => ({
       map.setLayoutProperty('sed_export', 'visibility', 'none')
     }
     map.setPaintProperty('watershed', 'fill-color', transparent)
+  },
+  setTopPolygonsFill: (layerId, polygonIds, fillColors) => {
+    const state = get()
+    const map = state.mapReference?.getMap()
+
+    if (!map) {
+      return
+    }
+
+    map.setPaintProperty(layerId, 'fill-color', [
+      'match',
+      ['get', 'watershed_id'],
+      polygonIds[0],
+      fillColors[0],
+      polygonIds[1],
+      fillColors[1],
+      polygonIds[2],
+      fillColors[2],
+      transparent,
+    ])
   },
 }))

--- a/src/stores/mapStore.ts
+++ b/src/stores/mapStore.ts
@@ -1,13 +1,19 @@
 import { create } from 'zustand'
 import { atlasBenthicColors, sedExportColorMapping, transparent } from '../data/mapData'
 import { MapRef } from 'react-map-gl/maplibre'
-import { buildWatershedMatchExpression, getUpdatedBenthicColor } from '../utils/mapUtils'
+import {
+  buildSedExportWatershedExpression,
+  buildWatershedMatchExpression,
+  getUpdatedBenthicColor,
+} from '../utils/mapUtils'
 
 type MapState = {
   mapReference: MapRef | null
   benthicMapSubLayerColors: Record<string, string>
   sedExportMapSubLayerColors: Record<string, string>
   topWatershedIds: number[]
+  sedExportMode: 'pixel' | 'watershed' | null
+  sedExportYear: number
 }
 type MapActions = {
   setMapRef: (map: MapRef) => void
@@ -30,6 +36,8 @@ export const useMapStore = create<MapState & MapActions>((set, get) => ({
   benthicMapSubLayerColors: atlasBenthicColors,
   sedExportMapSubLayerColors: sedExportColorMapping,
   topWatershedIds: [],
+  sedExportMode: null,
+  sedExportYear: 0,
   setBenthicMapSubLayerColors: (colors) => set({ benthicMapSubLayerColors: colors }),
   setSedExportMapSubLayerColors: (colors) => set({ sedExportMapSubLayerColors: colors }),
   toggleSubLayerFillColor: (toggledProperty) => {
@@ -54,7 +62,8 @@ export const useMapStore = create<MapState & MapActions>((set, get) => ({
     if (!map) {
       return
     }
-    const regionLevel = 'country' //TODO: pass in selected region level
+
+    set({ sedExportMode: subLayerToggledOn, sedExportYear: selectedYear })
 
     const pixelLayer = map.getLayer('sed_export')
     if (pixelLayer) {
@@ -65,42 +74,16 @@ export const useMapStore = create<MapState & MapActions>((set, get) => ({
       )
     }
 
-    const watershedSedExportThresholdFillExpression = [
-      'match',
-      ['get', `export_threshold_${regionLevel}_${selectedYear}`],
-      '0',
-      sedExportColorMapping['0'],
-      '1-10',
-      sedExportColorMapping['1-10'],
-      '10-20',
-      sedExportColorMapping['10-20'],
-      '20-50',
-      sedExportColorMapping['20-50'],
-      '50-75',
-      sedExportColorMapping['50-75'],
-      '75-90',
-      sedExportColorMapping['75-90'],
-      '90-100',
-      sedExportColorMapping['90-100'],
-      transparent,
-    ] as const
+    const baseFillExpression =
+      subLayerToggledOn === 'watershed'
+        ? buildSedExportWatershedExpression(selectedYear)
+        : transparent
 
-    if (subLayerToggledOn === 'watershed') {
-      map.setPaintProperty(
-        'watershed',
-        'fill-color',
-        buildWatershedMatchExpression(
-          state.topWatershedIds,
-          watershedSedExportThresholdFillExpression,
-        ),
-      )
-    } else {
-      map.setPaintProperty(
-        'watershed',
-        'fill-color',
-        buildWatershedMatchExpression(state.topWatershedIds, transparent),
-      )
-    }
+    map.setPaintProperty(
+      'watershed',
+      'fill-color',
+      buildWatershedMatchExpression(state.topWatershedIds, baseFillExpression),
+    )
   },
   turnOffSedExportSubLayerFills: () => {
     const state = get()
@@ -108,6 +91,8 @@ export const useMapStore = create<MapState & MapActions>((set, get) => ({
     if (!map) {
       return
     }
+
+    set({ sedExportMode: null })
 
     const pixelLayer = map.getLayer('sed_export')
     if (pixelLayer) {
@@ -131,8 +116,15 @@ export const useMapStore = create<MapState & MapActions>((set, get) => ({
       return
     }
 
+    // Restore the watershed choropleth when in watershed mode so the sed-export
+    // coloring remains visible after the top-polygon highlight is cleared.
+    const baseFillExpression =
+      state.sedExportMode === 'watershed'
+        ? buildSedExportWatershedExpression(state.sedExportYear)
+        : transparent
+
     set({ topWatershedIds: [] })
-    map.setPaintProperty(layerId, 'fill-color', transparent)
+    map.setPaintProperty(layerId, 'fill-color', baseFillExpression)
   },
   setTopPolygonsFill: (layerId, polygonIds) => {
     const state = get()
@@ -142,11 +134,18 @@ export const useMapStore = create<MapState & MapActions>((set, get) => ({
       return
     }
 
+    // Use the active watershed choropleth as the fallback so non-highlighted
+    // watersheds keep their sed-export colour while the top polygons are shown.
+    const baseFillExpression =
+      state.sedExportMode === 'watershed'
+        ? buildSedExportWatershedExpression(state.sedExportYear)
+        : transparent
+
     set({ topWatershedIds: polygonIds })
     map.setPaintProperty(
       layerId,
       'fill-color',
-      buildWatershedMatchExpression(polygonIds, transparent),
+      buildWatershedMatchExpression(polygonIds, baseFillExpression),
     )
   },
 }))

--- a/src/stores/mapStore.ts
+++ b/src/stores/mapStore.ts
@@ -2,11 +2,13 @@ import { create } from 'zustand'
 import { atlasBenthicColors, sedExportColorMapping, transparent } from '../data/mapData'
 import { MapRef } from 'react-map-gl/maplibre'
 import { getUpdatedBenthicColor } from '../utils/mapUtils'
+import { topContributingWatershedColorFills } from '../constants'
 
 type MapState = {
   mapReference: MapRef | null
   benthicMapSubLayerColors: Record<string, string>
   sedExportMapSubLayerColors: Record<string, string>
+  topWatershedIds: number[]
 }
 type MapActions = {
   setMapRef: (map: MapRef) => void
@@ -18,7 +20,8 @@ type MapActions = {
     selectedYear: number,
   ) => void
   turnOffSedExportSubLayerFills: () => void
-  setTopPolygonsFill: (layerId: string, polygonIds: number[], fillColors: string[]) => void
+  setTopPolygonsFill: (layerId: string, polygonIds: number[]) => void
+  setTopWatershedIds: (polygonIds: number[]) => void
   clearTopPolygonsFill: (layerId: string) => void
 }
 
@@ -27,6 +30,7 @@ export const useMapStore = create<MapState & MapActions>((set, get) => ({
   setMapRef: (mapRef) => set({ mapReference: mapRef }),
   benthicMapSubLayerColors: atlasBenthicColors,
   sedExportMapSubLayerColors: sedExportColorMapping,
+  topWatershedIds: [],
   setBenthicMapSubLayerColors: (colors) => set({ benthicMapSubLayerColors: colors }),
   setSedExportMapSubLayerColors: (colors) => set({ sedExportMapSubLayerColors: colors }),
   toggleSubLayerFillColor: (toggledProperty) => {
@@ -62,28 +66,54 @@ export const useMapStore = create<MapState & MapActions>((set, get) => ({
       )
     }
 
+    const topWatershedFillExpression =
+      state.topWatershedIds.length >= 3
+        ? ([
+            'match',
+            ['get', 'watershed_id'],
+            state.topWatershedIds[0],
+            topContributingWatershedColorFills[0],
+            state.topWatershedIds[1],
+            topContributingWatershedColorFills[1],
+            state.topWatershedIds[2],
+            topContributingWatershedColorFills[2],
+          ] as const)
+        : null
+
+    const watershedSedExportThresholdFillExpression = [
+      'match',
+      ['get', `export_threshold_${regionLevel}_${selectedYear}`],
+      '0',
+      sedExportColorMapping['0'],
+      '1-10',
+      sedExportColorMapping['1-10'],
+      '10-20',
+      sedExportColorMapping['10-20'],
+      '20-50',
+      sedExportColorMapping['20-50'],
+      '50-75',
+      sedExportColorMapping['50-75'],
+      '75-90',
+      sedExportColorMapping['75-90'],
+      '90-100',
+      sedExportColorMapping['90-100'],
+      transparent,
+    ] as const
+
     if (subLayerToggledOn === 'watershed') {
-      map.setPaintProperty('watershed', 'fill-color', [
-        'match',
-        ['get', `export_threshold_${regionLevel}_${selectedYear}`],
-        '0',
-        sedExportColorMapping['0'],
-        '1-10',
-        sedExportColorMapping['1-10'],
-        '10-20',
-        sedExportColorMapping['10-20'],
-        '20-50',
-        sedExportColorMapping['20-50'],
-        '50-75',
-        sedExportColorMapping['50-75'],
-        '75-90',
-        sedExportColorMapping['75-90'],
-        '90-100',
-        sedExportColorMapping['90-100'],
-        transparent, // default
-      ])
+      map.setPaintProperty(
+        'watershed',
+        'fill-color',
+        topWatershedFillExpression
+          ? [...topWatershedFillExpression, watershedSedExportThresholdFillExpression]
+          : watershedSedExportThresholdFillExpression,
+      )
     } else {
-      map.setPaintProperty('watershed', 'fill-color', transparent)
+      map.setPaintProperty(
+        'watershed',
+        'fill-color',
+        topWatershedFillExpression ? [...topWatershedFillExpression, transparent] : transparent,
+      )
     }
   },
   turnOffSedExportSubLayerFills: () => {
@@ -97,7 +127,22 @@ export const useMapStore = create<MapState & MapActions>((set, get) => ({
     if (pixelLayer) {
       map.setLayoutProperty('sed_export', 'visibility', 'none')
     }
-    map.setPaintProperty('watershed', 'fill-color', transparent)
+    const topWatershedFillExpression =
+      state.topWatershedIds.length >= 3
+        ? ([
+            'match',
+            ['get', 'watershed_id'],
+            state.topWatershedIds[0],
+            topContributingWatershedColorFills[0],
+            state.topWatershedIds[1],
+            topContributingWatershedColorFills[1],
+            state.topWatershedIds[2],
+            topContributingWatershedColorFills[2],
+            transparent,
+          ] as const)
+        : transparent
+
+    map.setPaintProperty('watershed', 'fill-color', topWatershedFillExpression)
   },
   clearTopPolygonsFill: (layerId) => {
     const state = get()
@@ -107,7 +152,10 @@ export const useMapStore = create<MapState & MapActions>((set, get) => ({
     }
     map.setPaintProperty(layerId, 'fill-color', transparent)
   },
-  setTopPolygonsFill: (layerId, polygonIds, fillColors) => {
+  setTopWatershedIds: (polygonIds) => {
+    set({ topWatershedIds: polygonIds })
+  },
+  setTopPolygonsFill: (layerId, polygonIds) => {
     const state = get()
     const map = state.mapReference?.getMap()
 
@@ -115,15 +163,19 @@ export const useMapStore = create<MapState & MapActions>((set, get) => ({
       return
     }
 
+    if (layerId === 'watershed') {
+      set({ topWatershedIds: polygonIds })
+    }
+
     map.setPaintProperty(layerId, 'fill-color', [
       'match',
       ['get', 'watershed_id'],
       polygonIds[0],
-      fillColors[0],
+      topContributingWatershedColorFills[0],
       polygonIds[1],
-      fillColors[1],
+      topContributingWatershedColorFills[1],
       polygonIds[2],
-      fillColors[2],
+      topContributingWatershedColorFills[2],
       transparent,
     ])
   },

--- a/src/stores/mapStore.ts
+++ b/src/stores/mapStore.ts
@@ -1,8 +1,7 @@
 import { create } from 'zustand'
 import { atlasBenthicColors, sedExportColorMapping, transparent } from '../data/mapData'
 import { MapRef } from 'react-map-gl/maplibre'
-import { getUpdatedBenthicColor } from '../utils/mapUtils'
-import { topContributingWatershedColorFills } from '../constants'
+import { buildWatershedMatchExpression, getUpdatedBenthicColor } from '../utils/mapUtils'
 
 type MapState = {
   mapReference: MapRef | null
@@ -66,20 +65,6 @@ export const useMapStore = create<MapState & MapActions>((set, get) => ({
       )
     }
 
-    const topWatershedFillExpression =
-      state.topWatershedIds.length >= 3
-        ? ([
-            'match',
-            ['get', 'watershed_id'],
-            state.topWatershedIds[0],
-            topContributingWatershedColorFills[0],
-            state.topWatershedIds[1],
-            topContributingWatershedColorFills[1],
-            state.topWatershedIds[2],
-            topContributingWatershedColorFills[2],
-          ] as const)
-        : null
-
     const watershedSedExportThresholdFillExpression = [
       'match',
       ['get', `export_threshold_${regionLevel}_${selectedYear}`],
@@ -104,15 +89,16 @@ export const useMapStore = create<MapState & MapActions>((set, get) => ({
       map.setPaintProperty(
         'watershed',
         'fill-color',
-        topWatershedFillExpression
-          ? [...topWatershedFillExpression, watershedSedExportThresholdFillExpression]
-          : watershedSedExportThresholdFillExpression,
+        buildWatershedMatchExpression(
+          state.topWatershedIds,
+          watershedSedExportThresholdFillExpression,
+        ),
       )
     } else {
       map.setPaintProperty(
         'watershed',
         'fill-color',
-        topWatershedFillExpression ? [...topWatershedFillExpression, transparent] : transparent,
+        buildWatershedMatchExpression(state.topWatershedIds, transparent),
       )
     }
   },
@@ -127,33 +113,26 @@ export const useMapStore = create<MapState & MapActions>((set, get) => ({
     if (pixelLayer) {
       map.setLayoutProperty('sed_export', 'visibility', 'none')
     }
-    const topWatershedFillExpression =
-      state.topWatershedIds.length >= 3
-        ? ([
-            'match',
-            ['get', 'watershed_id'],
-            state.topWatershedIds[0],
-            topContributingWatershedColorFills[0],
-            state.topWatershedIds[1],
-            topContributingWatershedColorFills[1],
-            state.topWatershedIds[2],
-            topContributingWatershedColorFills[2],
-            transparent,
-          ] as const)
-        : transparent
 
-    map.setPaintProperty('watershed', 'fill-color', topWatershedFillExpression)
+    map.setPaintProperty(
+      'watershed',
+      'fill-color',
+      buildWatershedMatchExpression(state.topWatershedIds, transparent),
+    )
+  },
+  setTopWatershedIds: (polygonIds) => {
+    set({ topWatershedIds: polygonIds })
   },
   clearTopPolygonsFill: (layerId) => {
     const state = get()
     const map = state.mapReference?.getMap()
+
     if (!map) {
       return
     }
+
+    set({ topWatershedIds: [] })
     map.setPaintProperty(layerId, 'fill-color', transparent)
-  },
-  setTopWatershedIds: (polygonIds) => {
-    set({ topWatershedIds: polygonIds })
   },
   setTopPolygonsFill: (layerId, polygonIds) => {
     const state = get()
@@ -163,20 +142,11 @@ export const useMapStore = create<MapState & MapActions>((set, get) => ({
       return
     }
 
-    if (layerId === 'watershed') {
-      set({ topWatershedIds: polygonIds })
-    }
-
-    map.setPaintProperty(layerId, 'fill-color', [
-      'match',
-      ['get', 'watershed_id'],
-      polygonIds[0],
-      topContributingWatershedColorFills[0],
-      polygonIds[1],
-      topContributingWatershedColorFills[1],
-      polygonIds[2],
-      topContributingWatershedColorFills[2],
-      transparent,
-    ])
+    set({ topWatershedIds: polygonIds })
+    map.setPaintProperty(
+      layerId,
+      'fill-color',
+      buildWatershedMatchExpression(polygonIds, transparent),
+    )
   },
 }))

--- a/src/stores/selectedFeatureStore.ts
+++ b/src/stores/selectedFeatureStore.ts
@@ -13,9 +13,10 @@ type PlumeWatershedStats = Record<number, ZonalStatsBand>
 type SelectedFeatureState = {
   selectedFeature: MinimalFeature | null
   setSelectedFeature: (feature: MapGeoJSONFeature | null) => void
-  clearSelectedFeature: () => void
   selectedPlumeWatershedStats: PlumeWatershedStats | null
   setSelectedPlumeWatershedStats: (stats: PlumeWatershedStats | null) => void
+  clearSelectedFeature: () => void
+  clearSelectedPlumeWatershedStats: () => void
 }
 
 export const useSelectedFeatureStore = create<SelectedFeatureState>((set) => ({
@@ -35,4 +36,5 @@ export const useSelectedFeatureStore = create<SelectedFeatureState>((set) => ({
     set({ selectedFeature: minimal })
   },
   clearSelectedFeature: () => set({ selectedFeature: null }),
+  clearSelectedPlumeWatershedStats: () => set({ selectedPlumeWatershedStats: null }),
 }))

--- a/src/stores/selectedFeatureStore.ts
+++ b/src/stores/selectedFeatureStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand'
 import { MapGeoJSONFeature } from 'maplibre-gl'
+import { ZonalStatsBand } from '../types/MapDataTypes'
 
 type MinimalFeature = {
   id: string | number
@@ -7,14 +8,20 @@ type MinimalFeature = {
   properties?: Record<string, unknown>
 }
 
+type PlumeWatershedStats = Record<number, ZonalStatsBand>
+
 type SelectedFeatureState = {
   selectedFeature: MinimalFeature | null
   setSelectedFeature: (feature: MapGeoJSONFeature | null) => void
   clearSelectedFeature: () => void
+  selectedPlumeWatershedStats: PlumeWatershedStats | null
+  setSelectedPlumeWatershedStats: (stats: PlumeWatershedStats | null) => void
 }
 
 export const useSelectedFeatureStore = create<SelectedFeatureState>((set) => ({
   selectedFeature: null,
+  selectedPlumeWatershedStats: null,
+  setSelectedPlumeWatershedStats: (stats) => set({ selectedPlumeWatershedStats: stats }),
   setSelectedFeature: (feature) => {
     if (!feature) {
       set({ selectedFeature: null })

--- a/src/styles/theme.scss
+++ b/src/styles/theme.scss
@@ -7,6 +7,7 @@ $white: #ffffff;
 $grey: #dedfe3;
 $greyWhite: #fafbfc;
 $hoverGrey: #f1f2f3;
+$accentBlue: #334bff;
 
 /** Fonts, font styling, text **/
 $textColor: #393939;

--- a/src/tests/mapUtils.test.ts
+++ b/src/tests/mapUtils.test.ts
@@ -1,4 +1,6 @@
 import {
+  buildSedExportWatershedExpression,
+  buildWatershedMatchExpression,
   createPolygonClickHandler,
   createPolygonHoverHandler,
   getActiveLayers,
@@ -7,6 +9,8 @@ import {
 import { Map, MapGeoJSONFeature, MapLayerMouseEvent } from 'maplibre-gl'
 import { RefObject } from 'react'
 import { regionOptions } from '../data/regionData'
+import { sedExportColorMapping, transparent } from '../data/mapData'
+import { topContributingWatershedColorFills } from '../constants'
 import { LayerInfo } from '../types/MapDataTypes'
 
 const mockUrl = 'https://things.com'
@@ -226,6 +230,68 @@ describe('map utilities', () => {
           _sw: expect.any(Object),
         }),
       )
+    })
+  })
+
+  describe('buildWatershedMatchExpression', () => {
+    it('returns the fallback directly when the id list is empty', () => {
+      expect(buildWatershedMatchExpression([], transparent)).toBe(transparent)
+    })
+
+    it('returns the fallback directly when the id list is empty and fallback is an expression', () => {
+      const expr = ['match', ['get', 'foo'], 'a', '#fff', transparent]
+      expect(buildWatershedMatchExpression([], expr)).toBe(expr)
+    })
+
+    it('builds a match expression assigning colours to each watershed id', () => {
+      const ids = [974529, 977314]
+      const result = buildWatershedMatchExpression(ids, transparent)
+      expect(result).toEqual([
+        'match',
+        ['get', 'watershed_id'],
+        974529,
+        topContributingWatershedColorFills[0],
+        977314,
+        topContributingWatershedColorFills[1],
+        transparent,
+      ])
+    })
+
+    it('accepts an expression array as the fallback', () => {
+      const choropleth = buildSedExportWatershedExpression(2020)
+      const result = buildWatershedMatchExpression([974529], choropleth) as unknown[]
+      expect(result[0]).toBe('match')
+      expect(result[result.length - 1]).toBe(choropleth)
+    })
+  })
+
+  describe('buildSedExportWatershedExpression', () => {
+    it('returns a match expression with the correct property key for the given year', () => {
+      const result = buildSedExportWatershedExpression(2020) as unknown[]
+      expect(result[0]).toBe('match')
+      expect(result[1]).toEqual(['get', 'export_threshold_country_2020'])
+    })
+
+    it('interpolates the year into the property name', () => {
+      const result2000 = buildSedExportWatershedExpression(2000) as unknown[]
+      const result2015 = buildSedExportWatershedExpression(2015) as unknown[]
+      expect(result2000[1]).toEqual(['get', 'export_threshold_country_2000'])
+      expect(result2015[1]).toEqual(['get', 'export_threshold_country_2015'])
+    })
+
+    it('maps every sedExportColorMapping band to the correct colour', () => {
+      const result = buildSedExportWatershedExpression(2020)
+      const bands = ['0', '1-10', '10-20', '20-50', '50-75', '75-90', '90-100']
+      bands.forEach((band) => {
+        const bandIndex = result.indexOf(band)
+        expect(bandIndex).toBeGreaterThan(-1)
+        expect(result[bandIndex + 1]).toBe(sedExportColorMapping[band])
+      })
+    })
+
+    it('uses transparent as the final fallback', () => {
+      const result = buildSedExportWatershedExpression(2020)
+      expect(result[result.length - 1]).toBe(transparent)
     })
   })
 })

--- a/src/types/MapDataTypes.ts
+++ b/src/types/MapDataTypes.ts
@@ -24,3 +24,11 @@ export interface SubLayerInfo {
   isLayerOn: boolean
   layerId: string
 }
+
+export interface ZonalStatsBand {
+  [band_id: string]: {
+    majority: number
+    aoi_area: number
+    data_area: number
+  }
+}

--- a/src/utils/chartUtils.ts
+++ b/src/utils/chartUtils.ts
@@ -1,5 +1,6 @@
 import i18next from 'i18next'
 import { ChartData, ChartProperties, ChartSeriesName } from '../types/ChartDataTypes'
+import { ZonalStatsBand } from '../types/MapDataTypes'
 import { chartSeriesConfig } from '../data/chartSeriesData'
 import { MapGeoJSONFeature } from 'maplibre-gl'
 import { Dispatch, SetStateAction } from 'react'
@@ -79,6 +80,81 @@ export const getBoundaryFileChartData = (pointProperties): LulcAndSedimentSeries
     }
   }
   return chartSeriesData
+}
+type PlumeStatsEntries = [string, ZonalStatsBand][]
+
+export const mapChartConfigToPlumeData = (
+  plumeStatsValue: PlumeStatsEntries,
+): ChartProperties[] => {
+  const sedimentChartName = 'sediment_exposure_historical'
+  const sedimentConfig = chartSeriesConfig[`charts.${sedimentChartName}`]
+  const sedXAxisTitle = i18next.t(sedimentConfig.xAxisTitle)
+
+  const watershedsChartName = 'contributing_watersheds'
+  const watershedConfig = chartSeriesConfig[`charts.${watershedsChartName}`]
+  const watershedXAxisTitle = i18next.t(watershedConfig.xAxisTitle)
+
+  const watershedBandMap: Record<string, string> = {
+    w1: 'band_5',
+    w2: 'band_6',
+    w3: 'band_7',
+  }
+
+  const sedimentTraceName = i18next.t('land_types.sediment')
+  const sedimentBar: Partial<PlotData>[] = [
+    {
+      type: 'bar',
+      marker: { color: sedimentConfig.legendColors.sediment },
+      hovertemplate: `${sedXAxisTitle}: %{x}<br />${sedimentTraceName}: %{y:.2f}T<extra></extra>`,
+      name: sedimentTraceName,
+      width: sedimentConfig.width,
+      x: plumeStatsValue.map(([year]) => year),
+      y: plumeStatsValue.map(([, stats]) => stats?.band_1?.majority ?? 0),
+    },
+  ]
+
+  const watershedBars: Partial<PlotData>[] = Object.entries(watershedBandMap)
+    .reverse()
+    .map(([key, band]) => {
+      const name = i18next.t(`charts.${key}`)
+      const polutionPercentage = i18next.t('chart_information.pollution')
+
+      return {
+        type: 'bar',
+        marker: { color: watershedConfig.legendColors[key] },
+        hovertemplate: `${watershedXAxisTitle}: %{x}<br />${polutionPercentage}: %{y}%<extra></extra>`,
+        name,
+        width: watershedConfig.width,
+        x: plumeStatsValue.map(([year]) => year),
+        y: plumeStatsValue.map(([, stats]) => stats?.[band]?.majority ?? 0),
+      }
+    })
+
+  return [
+    {
+      barmode: sedimentConfig.barmode ?? 'group',
+      chartName: i18next.t(sedimentChartName),
+      chartSeriesData: sedimentBar,
+      xAxisTitle: sedXAxisTitle,
+      yAxisTitle: i18next.t(sedimentConfig.yAxisTitle),
+    },
+    {
+      barmode: watershedConfig.barmode ?? 'stack',
+      chartName: i18next.t(watershedsChartName),
+      chartSeriesData: watershedBars,
+      xAxisTitle: watershedXAxisTitle,
+      yAxisTitle: i18next.t(watershedConfig.yAxisTitle),
+    },
+  ]
+}
+
+export const updatePlumeChartData = (
+  plumeStats: Record<string, ZonalStatsBand>,
+  setChartData: Dispatch<SetStateAction<ChartProperties[] | null>>,
+) => {
+  const plumeStatsValue: PlumeStatsEntries = Object.entries(plumeStats)
+  const plumeMappedData = mapChartConfigToPlumeData(plumeStatsValue)
+  setChartData(plumeMappedData)
 }
 
 export const mapChartConfigToData = (

--- a/src/utils/chartUtils.ts
+++ b/src/utils/chartUtils.ts
@@ -160,14 +160,14 @@ export const mapChartConfigToPlumeData = (
   return [
     {
       barmode: sedimentConfig.barmode ?? 'group',
-      chartName: i18next.t(sedimentChartName),
+      chartName: sedimentChartName,
       chartSeriesData: sedimentBar,
       xAxisTitle: sedXAxisTitle,
       yAxisTitle: i18next.t(sedimentConfig.yAxisTitle),
     },
     {
       barmode: watershedConfig.barmode ?? 'stack',
-      chartName: i18next.t(watershedsChartName),
+      chartName: watershedsChartName,
       chartSeriesData: watershedBars,
       xAxisTitle: watershedXAxisTitle,
       yAxisTitle: i18next.t(watershedConfig.yAxisTitle),

--- a/src/utils/chartUtils.ts
+++ b/src/utils/chartUtils.ts
@@ -5,6 +5,34 @@ import { chartSeriesConfig } from '../data/chartSeriesData'
 import { MapGeoJSONFeature } from 'maplibre-gl'
 import { Dispatch, SetStateAction } from 'react'
 import { PlotData } from 'plotly.js'
+import { RegionType } from '../types/RegionDataTypes'
+
+export function getDrawerTitle(regionType: RegionType, fallbackLabel: string): string {
+  if (regionType === 'global') {
+    return 'global_trends'
+  }
+  if (regionType === 'watershed') {
+    return 'watershed_information'
+  }
+  if (regionType === 'plume') {
+    return 'ocean_pollution'
+  }
+  return fallbackLabel
+}
+
+export function getEffectiveRegionType(
+  selectedPlumeWatershedStats: Record<number, ZonalStatsBand> | null,
+  selectedFeatureSource: string | undefined,
+  regionType: RegionType,
+): RegionType {
+  if (selectedPlumeWatershedStats) {
+    return 'plume'
+  }
+  if (selectedFeatureSource === 'watershed_src') {
+    return 'watershed'
+  }
+  return regionType
+}
 
 //'Built_pct_2000': val --> 'built_up': {{"2015": val}, {"2005": val}, ...}
 const areaRegex = new RegExp(/.*(area_ha)_\d{4}/, 'gm')
@@ -117,12 +145,11 @@ export const mapChartConfigToPlumeData = (
     .reverse()
     .map(([key, band]) => {
       const name = i18next.t(`charts.${key}`)
-      const polutionPercentage = i18next.t('chart_information.pollution')
 
       return {
         type: 'bar',
         marker: { color: watershedConfig.legendColors[key] },
-        hovertemplate: `${watershedXAxisTitle}: %{x}<br />${polutionPercentage}: %{y}%<extra></extra>`,
+        hovertemplate: `${watershedXAxisTitle}: %{x}<br />${name}: %{y}%<extra></extra>`,
         name,
         width: watershedConfig.width,
         x: plumeStatsValue.map(([year]) => year),

--- a/src/utils/mapUtils.ts
+++ b/src/utils/mapUtils.ts
@@ -10,6 +10,7 @@ import {
 import { RefObject } from 'react'
 import { LayerInfo, SubLayerInfo } from '../types/MapDataTypes'
 import { atlasBenthicColors, transparent } from '../data/mapData'
+import { BASE_ZONAL_STATS_API, SEDIMENT_EXPOSURE_2000_URL } from '../constants'
 
 export function getActiveLayers(mapLayers: LayerInfo[]): string[] {
   return mapLayers.filter((layer) => layer.isLayerOn).map((layer) => layer.layerId)
@@ -254,4 +255,37 @@ export function mapRegionSelected(feature: MapGeoJSONFeature): RegionOption {
     return { ...matchingRegion, regionType: 'watershed' }
   }
   return matchingRegion || regionOptions[0]
+}
+
+export async function postZonalStats(payload) {
+  try {
+    const response = await fetch(BASE_ZONAL_STATS_API, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+    })
+
+    if (!response.ok) {
+      throw new Error(`HTTP error, status: ${response.status}`)
+    }
+
+    return await response.json()
+  } catch (err) {
+    throw new Error(`HTTP error: ${err}`)
+  }
+}
+
+export async function prepareZonalStatsCall(lngLat) {
+  const { lat, lng } = lngLat
+  //todo: check if selected year has available exposure url
+
+  const basePayload = {
+    aoi: { type: 'Point', coordinates: [lng, lat] },
+    url: SEDIMENT_EXPOSURE_2000_URL, //todo: use year as parameter
+    bands: [1, 2, 3, 4, 5, 6, 7],
+    stats: ['majority'],
+  }
+  return await postZonalStats(basePayload)
 }

--- a/src/utils/mapUtils.ts
+++ b/src/utils/mapUtils.ts
@@ -1,3 +1,5 @@
+import booleanPointInPolygon from '@turf/boolean-point-in-polygon'
+import type { Feature, Polygon, MultiPolygon } from 'geojson'
 import { RegionOption } from '../types/RegionDataTypes'
 import { regionOptions } from '../data/regionData'
 import {
@@ -245,6 +247,67 @@ export function querySourceFeatureWhenReady(
     }
     const feature = tryQuery()
     if (feature) {
+      settle(feature)
+    }
+  }
+  map.on('sourcedata', onSourceData)
+
+  const timeoutId = setTimeout(() => settle(null), timeoutMs)
+
+  return () => settle(null)
+}
+
+/**
+ * Queries a vector tile source for a polygon feature spatially containing `point`,
+ * retrying as tiles stream in. Viewport-independent (uses querySourceFeatures).
+ * Calls onResult with the first matching feature, or null if the timeout expires.
+ * Returns a cancel function suitable as useEffect cleanup.
+ */
+export function querySourceFeatureAtPointWhenReady(
+  map: Map,
+  sourceId: string,
+  sourceLayer: string,
+  point: { lng: number; lat: number },
+  onResult: (feature: MapGeoJSONFeature | null) => void,
+  timeoutMs = 10_000,
+): () => void {
+  const findContainingFeature = (): MapGeoJSONFeature | null => {
+    const features = map.querySourceFeatures(sourceId, { sourceLayer })
+    const match = features.find(
+      (f) =>
+        (f.geometry.type === 'Polygon' || f.geometry.type === 'MultiPolygon') &&
+        booleanPointInPolygon([point.lng, point.lat], f as Feature<Polygon | MultiPolygon>),
+    )
+    return (match as MapGeoJSONFeature | undefined) ?? null
+  }
+
+  // Resolve immediately: either a match was found, or all tiles are loaded with no match.
+  const initial = findContainingFeature()
+  if (initial || map.isSourceLoaded(sourceId)) {
+    onResult(initial)
+    return () => {}
+  }
+
+  // Source is still streaming — retry on each new tile batch.
+  let settled = false
+
+  const settle = (result: MapGeoJSONFeature | null) => {
+    if (settled) {
+      return
+    }
+    settled = true
+    map.off('sourcedata', onSourceData)
+    clearTimeout(timeoutId)
+    onResult(result)
+  }
+
+  const onSourceData = (e: { sourceId?: string; isSourceLoaded?: boolean }) => {
+    if (settled || e.sourceId !== sourceId) {
+      return
+    }
+    const feature = findContainingFeature()
+    // Settle as soon as a match is found, or all tiles are loaded with no match.
+    if (feature || e.isSourceLoaded) {
       settle(feature)
     }
   }

--- a/src/utils/mapUtils.ts
+++ b/src/utils/mapUtils.ts
@@ -296,7 +296,7 @@ export async function postZonalStats(payload) {
 
     return await response.json()
   } catch (err) {
-    throw new Error(`HTTP error: ${err}`)
+    throw new Error('Zonal stats request failed', { cause: err })
   }
 }
 

--- a/src/utils/mapUtils.ts
+++ b/src/utils/mapUtils.ts
@@ -18,6 +18,8 @@ import {
   SEDIMENT_EXPOSURE_2015_URL,
   SEDIMENT_EXPOSURE_2020_URL,
 } from '../constants'
+import { useSelectedFeatureStore } from '../stores/selectedFeatureStore'
+import { useMapStore } from '../stores/mapStore'
 
 export function getActiveLayers(mapLayers: LayerInfo[]): string[] {
   return mapLayers.filter((layer) => layer.isLayerOn).map((layer) => layer.layerId)
@@ -134,8 +136,11 @@ export function createPolygonHoverHandler(hoveredRef: RefObject<string | number 
 export function createPolygonClickHandler(
   polygonClickedRef: RefObject<string | number | null>,
   onSelect?: (feature: MapGeoJSONFeature | null, bounds?: LngLatBounds) => void,
+  setClickedPlumePoint?: (point: { lng: number; lat: number } | null) => void,
 ) {
   return (map: Map, e: MapLayerMouseEvent, mapDataLayer: LayerInfo) => {
+    const { clearSelectedPlumeWatershedStats } = useSelectedFeatureStore.getState()
+    const { clearTopPolygonsFill } = useMapStore.getState()
     if (!e.features || e.features.length === 0) {
       return
     }
@@ -146,6 +151,10 @@ export function createPolygonClickHandler(
     if (!featureId) {
       return
     }
+
+    clearSelectedPlumeWatershedStats()
+    setClickedPlumePoint?.(null)
+    clearTopPolygonsFill('watershed')
 
     // Clicking an already-selected watershed recenters the map on it
     if (polygonClickedRef.current === featureId) {

--- a/src/utils/mapUtils.ts
+++ b/src/utils/mapUtils.ts
@@ -17,9 +17,8 @@ import {
   SEDIMENT_EXPOSURE_2010_URL,
   SEDIMENT_EXPOSURE_2015_URL,
   SEDIMENT_EXPOSURE_2020_URL,
+  topContributingWatershedColorFills,
 } from '../constants'
-import { useSelectedFeatureStore } from '../stores/selectedFeatureStore'
-import { useMapStore } from '../stores/mapStore'
 
 export function getActiveLayers(mapLayers: LayerInfo[]): string[] {
   return mapLayers.filter((layer) => layer.isLayerOn).map((layer) => layer.layerId)
@@ -254,6 +253,21 @@ export function querySourceFeatureWhenReady(
   const timeoutId = setTimeout(() => settle(null), timeoutMs)
 
   return () => settle(null)
+}
+
+/**
+ * Builds a MapLibre `match` expression that assigns a colour to each watershed ID.
+ * Falls back to `fallback` for any ID not in the list, or when `ids` is empty.
+ */
+export function buildWatershedMatchExpression(
+  ids: number[],
+  fallback: string | readonly unknown[],
+): unknown {
+  if (ids.length === 0) {
+    return fallback
+  }
+  const pairs = ids.flatMap((id, i) => [id, topContributingWatershedColorFills[i]])
+  return ['match', ['get', 'watershed_id'], ...pairs, fallback]
 }
 
 export function mapRegionSelected(feature: MapGeoJSONFeature): RegionOption {

--- a/src/utils/mapUtils.ts
+++ b/src/utils/mapUtils.ts
@@ -10,7 +10,14 @@ import {
 import { RefObject } from 'react'
 import { LayerInfo, SubLayerInfo } from '../types/MapDataTypes'
 import { atlasBenthicColors, transparent } from '../data/mapData'
-import { BASE_ZONAL_STATS_API, SEDIMENT_EXPOSURE_2000_URL } from '../constants'
+import {
+  BASE_ZONAL_STATS_API,
+  SEDIMENT_EXPOSURE_2000_URL,
+  SEDIMENT_EXPOSURE_2005_URL,
+  SEDIMENT_EXPOSURE_2010_URL,
+  SEDIMENT_EXPOSURE_2015_URL,
+  SEDIMENT_EXPOSURE_2020_URL,
+} from '../constants'
 
 export function getActiveLayers(mapLayers: LayerInfo[]): string[] {
   return mapLayers.filter((layer) => layer.isLayerOn).map((layer) => layer.layerId)
@@ -277,15 +284,42 @@ export async function postZonalStats(payload) {
   }
 }
 
-export async function prepareZonalStatsCall(lngLat) {
+export async function prepareZonalStatsCall(lngLat, year) {
   const { lat, lng } = lngLat
   //todo: check if selected year has available exposure url
+  const exposureUrls = {
+    2000: SEDIMENT_EXPOSURE_2000_URL,
+    2005: SEDIMENT_EXPOSURE_2005_URL,
+    2010: SEDIMENT_EXPOSURE_2010_URL,
+    2015: SEDIMENT_EXPOSURE_2015_URL,
+    2020: SEDIMENT_EXPOSURE_2020_URL,
+  }
 
   const basePayload = {
     aoi: { type: 'Point', coordinates: [lng, lat] },
-    url: SEDIMENT_EXPOSURE_2000_URL, //todo: use year as parameter
+    url: exposureUrls[year], //todo: use year as parameter
     bands: [1, 2, 3, 4, 5, 6, 7],
     stats: ['majority'],
   }
   return await postZonalStats(basePayload)
+}
+
+export async function getAllYearZonalStats(lngLat) {
+  const years = [2000, 2005, 2010, 2015, 2020]
+  const availableYears = [2000]
+
+  const zonalStatsPromises = years.map(async (year) => {
+    if (!availableYears.includes(year)) {
+      return { [year]: {} }
+    }
+    try {
+      const stats = await prepareZonalStatsCall(lngLat, year)
+      return { [year]: stats }
+    } catch {
+      return { [year]: {} }
+    }
+  })
+
+  const results = await Promise.all(zonalStatsPromises)
+  return Object.assign({}, ...results)
 }

--- a/src/utils/mapUtils.ts
+++ b/src/utils/mapUtils.ts
@@ -136,11 +136,8 @@ export function createPolygonHoverHandler(hoveredRef: RefObject<string | number 
 export function createPolygonClickHandler(
   polygonClickedRef: RefObject<string | number | null>,
   onSelect?: (feature: MapGeoJSONFeature | null, bounds?: LngLatBounds) => void,
-  setClickedPlumePoint?: (point: { lng: number; lat: number } | null) => void,
 ) {
   return (map: Map, e: MapLayerMouseEvent, mapDataLayer: LayerInfo) => {
-    const { clearSelectedPlumeWatershedStats } = useSelectedFeatureStore.getState()
-    const { clearTopPolygonsFill } = useMapStore.getState()
     if (!e.features || e.features.length === 0) {
       return
     }
@@ -151,10 +148,6 @@ export function createPolygonClickHandler(
     if (!featureId) {
       return
     }
-
-    clearSelectedPlumeWatershedStats()
-    setClickedPlumePoint?.(null)
-    clearTopPolygonsFill('watershed')
 
     // Clicking an already-selected watershed recenters the map on it
     if (polygonClickedRef.current === featureId) {

--- a/src/utils/mapUtils.ts
+++ b/src/utils/mapUtils.ts
@@ -11,7 +11,7 @@ import {
 } from 'maplibre-gl'
 import { RefObject } from 'react'
 import { LayerInfo, SubLayerInfo } from '../types/MapDataTypes'
-import { atlasBenthicColors, transparent } from '../data/mapData'
+import { atlasBenthicColors, sedExportColorMapping, transparent } from '../data/mapData'
 import {
   BASE_ZONAL_STATS_API,
   SEDIMENT_EXPOSURE_2000_URL,
@@ -331,6 +331,34 @@ export function buildWatershedMatchExpression(
   }
   const pairs = ids.flatMap((id, i) => [id, topContributingWatershedColorFills[i]])
   return ['match', ['get', 'watershed_id'], ...pairs, fallback]
+}
+
+/**
+ * Builds the MapLibre `match` expression for the watershed choropleth
+ * (sed-export threshold percentile bands). The region level is currently
+ * fixed to 'country' — update when the UI exposes region-level selection.
+ */
+export function buildSedExportWatershedExpression(selectedYear: number): unknown[] {
+  const regionLevel = 'country' // TODO: pass in selected region level
+  return [
+    'match',
+    ['get', `export_threshold_${regionLevel}_${selectedYear}`],
+    '0',
+    sedExportColorMapping['0'],
+    '1-10',
+    sedExportColorMapping['1-10'],
+    '10-20',
+    sedExportColorMapping['10-20'],
+    '20-50',
+    sedExportColorMapping['20-50'],
+    '50-75',
+    sedExportColorMapping['50-75'],
+    '75-90',
+    sedExportColorMapping['75-90'],
+    '90-100',
+    sedExportColorMapping['90-100'],
+    transparent,
+  ]
 }
 
 export function mapRegionSelected(feature: MapGeoJSONFeature): RegionOption {

--- a/src/utils/routeUtils.ts
+++ b/src/utils/routeUtils.ts
@@ -78,3 +78,19 @@ export function getValidLatLng(
 
   return { lat, lng }
 }
+
+export function getValidDispersalPoint(
+  dispersalPointSearchParam: string | null,
+): { lat: number; lng: number } | null {
+  if (!dispersalPointSearchParam) {
+    return null
+  }
+
+  const parts = dispersalPointSearchParam.split(',')
+  if (parts.length !== 2) {
+    return null
+  }
+
+  const { lat, lng } = getValidLatLng(parts[0], parts[1])
+  return lat !== null && lng !== null ? { lat, lng } : null
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2883,6 +2883,17 @@
     "@types/geojson" "^7946.0.10"
     tslib "^2.8.1"
 
+"@turf/boolean-point-in-polygon@^7.3.4":
+  version "7.3.4"
+  resolved "https://registry.yarnpkg.com/@turf/boolean-point-in-polygon/-/boolean-point-in-polygon-7.3.4.tgz#654a940939fecddf1887ca4c95bd5a2f07a42de8"
+  integrity sha512-v/4hfyY90Vz9cDgs2GwjQf+Lft8o7mNCLJOTz/iv8SHAIgMMX0czEoIaNVOJr7tBqPqwin1CGwsncrkf5C9n8Q==
+  dependencies:
+    "@turf/helpers" "7.3.4"
+    "@turf/invariant" "7.3.4"
+    "@types/geojson" "^7946.0.10"
+    point-in-polygon-hao "^1.1.0"
+    tslib "^2.8.1"
+
 "@turf/centroid@^7.1.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@turf/centroid/-/centroid-7.2.0.tgz#3211fe81d68b65082c7be72bf099b33b9211b282"
@@ -2893,11 +2904,28 @@
     "@types/geojson" "^7946.0.10"
     tslib "^2.8.1"
 
+"@turf/helpers@7.3.4":
+  version "7.3.4"
+  resolved "https://registry.yarnpkg.com/@turf/helpers/-/helpers-7.3.4.tgz#a8c918981599dddcf452421c7b307c5832d05f02"
+  integrity sha512-U/S5qyqgx3WTvg4twaH0WxF3EixoTCfDsmk98g1E3/5e2YKp7JKYZdz0vivsS5/UZLJeZDEElOSFH4pUgp+l7g==
+  dependencies:
+    "@types/geojson" "^7946.0.10"
+    tslib "^2.8.1"
+
 "@turf/helpers@^7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@turf/helpers/-/helpers-7.2.0.tgz#5771308108c98d608eb8e7f16dcd0eb3fb8a3417"
   integrity sha512-cXo7bKNZoa7aC7ydLmUR02oB3IgDe7MxiPuRz3cCtYQHn+BJ6h1tihmamYDWWUlPHgSNF0i3ATc4WmDECZafKw==
   dependencies:
+    "@types/geojson" "^7946.0.10"
+    tslib "^2.8.1"
+
+"@turf/invariant@7.3.4":
+  version "7.3.4"
+  resolved "https://registry.yarnpkg.com/@turf/invariant/-/invariant-7.3.4.tgz#d81f448aa4fdda36047337a688517581e91c12f0"
+  integrity sha512-88Eo4va4rce9sNZs6XiMJowWkikM3cS2TBhaCKlU+GFHdNf8PFEpiU42VDU8q5tOF6/fu21Rvlke5odgOGW4AQ==
+  dependencies:
+    "@turf/helpers" "7.3.4"
     "@types/geojson" "^7946.0.10"
     tslib "^2.8.1"
 
@@ -7750,6 +7778,13 @@ pmtiles@^4.3.0:
   dependencies:
     fflate "^0.8.2"
 
+point-in-polygon-hao@^1.1.0:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/point-in-polygon-hao/-/point-in-polygon-hao-1.2.4.tgz#8662abdcc84bcca230cc3ecbb0b0ab1a306f1bd6"
+  integrity sha512-x2pcvXeqhRHlNRdhLs/tgFapAbSSe86wa/eqmj1G6pWftbEs5aVRJhRGM6FYSUERKu0PjekJzMq0gsI2XyiclQ==
+  dependencies:
+    robust-predicates "^3.0.2"
+
 point-in-polygon@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/point-in-polygon/-/point-in-polygon-1.1.0.tgz#b0af2616c01bdee341cbf2894df643387ca03357"
@@ -8262,6 +8297,11 @@ right-now@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/right-now/-/right-now-1.0.0.tgz#6e89609deebd7dcdaf8daecc9aea39cf585a0918"
   integrity sha512-DA8+YS+sMIVpbsuKgy+Z67L9Lxb1p05mNxRpDPNksPDEFir4vmBlUtuN9jkTGn9YMMdlBuK7XQgFiz6ws+yhSg==
+
+robust-predicates@^3.0.2:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/robust-predicates/-/robust-predicates-3.0.3.tgz#1099061b3349e2c5abec6c2ab0acd440d24d4062"
+  integrity sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==
 
 rollup@^4.40.0:
   version "4.59.0"


### PR DESCRIPTION
## Every PR

Before merging, the developer of this pull request has checked the following:

- [x] Changes have been tested locally without errors
- [x] Lint has run and any errors have been resolved
- [x] Prettier has run on any changed files
- [x] Storybook stories have run and any errors have been resolved
- [ ] Pre-existing unit tests have run and passed
  - [ ] Unit tests have been added or updated, where possible, to prevent future regressions

## Post-Merge

- [ ] Code has merged and build success is confirmed in 'Actions'
- [ ] The corresponding Trello ticket has moved to the appropriate list (likely User-QA)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Added plume selection capability by clicking on the map with interactive watershed data display
- Introduced top contributing watershed highlighting and visualization
- Added sediment exposure data visualization across multiple years (2000–2020)
- Added ocean pollution region support to the interface

<!-- end of auto-generated comment: release notes by coderabbit.ai -->