### PR TITLE
fix: [C159] Fit to watershed bounds when selecting polygon in different region

### DIFF
--- a/src/components/BaseMap/BaseMap.stories.ts
+++ b/src/components/BaseMap/BaseMap.stories.ts
@@ -17,9 +17,7 @@ export const Primary: Story = {
     sedExportSubLayerValue: 'pixel',
     onRegionChange: () => {},
     onWatershedChange: () => {},
-    initialWatershedId: null,
-    hasExplicitViewState: false,
-    selectedRegion: defaultGlobalRegionOption,
+    watershedId: null,
     setBreadcrumb: () => {},
     initialViewState: {
       longitude: defaultGlobalRegionOption.centerCoord.lng,
@@ -47,9 +45,7 @@ export const Loading: Story = {
     mapLayers: layers,
     onRegionChange: () => {},
     onWatershedChange: () => {},
-    initialWatershedId: null,
-    hasExplicitViewState: false,
-    selectedRegion: defaultGlobalRegionOption,
+    watershedId: null,
     setBreadcrumb: () => {},
     sedExportSubLayerValue: 'pixel',
     initialViewState: {

--- a/src/components/BaseMap/BaseMap.tsx
+++ b/src/components/BaseMap/BaseMap.tsx
@@ -176,12 +176,11 @@ function PmTileLayers({ layer, index }) {
 interface BaseMapProps {
   mapLayers: LayerInfo[]
   sedExportSubLayerValue: 'pixel' | 'watershed'
-  selectedRegion: RegionOption
   onRegionChange: (region: RegionOption) => void
   onWatershedChange: (id: string | null) => void
-  initialWatershedId: string | null
-  hasExplicitViewState: boolean
+  watershedId: string | null
   setBreadcrumb: Dispatch<SetStateAction<RegionOption[]>>
+  onWatershedRestored?: (bounds: LngLatBounds) => void
   initialViewState: {
     longitude: number
     latitude: number
@@ -193,12 +192,11 @@ interface BaseMapProps {
 export default function BaseMap({
   mapLayers,
   sedExportSubLayerValue,
-  selectedRegion,
   onRegionChange,
   onWatershedChange,
-  initialWatershedId,
-  hasExplicitViewState,
+  watershedId,
   setBreadcrumb,
+  onWatershedRestored,
   initialViewState,
   onMapMoveEnd,
 }: BaseMapProps) {
@@ -219,61 +217,63 @@ export default function BaseMap({
 
   const setSelectedFeature = useSelectedFeatureStore((s) => s.setSelectedFeature)
 
+  // Build and set the watershed breadcrumb from a feature's properties.
+  // Shared by both the click path and the restoration path.
+  const applyWatershedBreadcrumb = useCallback(
+    (feature: MapGeoJSONFeature, bounds: LngLatBounds, currentZoom: number) => {
+      // TODO: for plume, use different property lookup
+      const countryOrRegion = feature.properties.TERRITORY1 || feature.properties.REALM
+      const addtlRegion: RegionOption | undefined = getRegionByLabel(countryOrRegion)
+      const subRegionWithUpdatedConfig: RegionOption = {
+        id: 'watershed',
+        regionType: 'watershed',
+        label: 'Watershed',
+        centerCoord: bounds.getCenter(),
+        zoomLevel: currentZoom,
+        grouping: 3,
+      }
+
+      // Breadcrumb: Global > [Country] > Watershed
+      // Country is omitted if it can't be determined from the feature
+      const updatedRegions: RegionOption[] = [defaultGlobalRegionOption]
+      if (addtlRegion) {
+        updatedRegions.push(addtlRegion)
+      }
+      updatedRegions.push(subRegionWithUpdatedConfig)
+
+      setBreadcrumb(updatedRegions)
+
+      return addtlRegion
+    },
+    [setBreadcrumb],
+  )
+
   const handleFeatureSelect = useCallback(
-    (
-      feature: MapGeoJSONFeature | null,
-      bounds?: LngLatBounds,
-      options?: { skipFitBounds?: boolean },
-    ) => {
+    (feature: MapGeoJSONFeature | null, bounds?: LngLatBounds) => {
       setSelectedFeature(feature)
 
       if (feature && bounds) {
         const map = mapRef.current?.getMap()
 
         if (map) {
-          // TODO: for plume, use different property lookup
-          const countryOrRegion = feature.properties.TERRITORY1 || feature.properties.REALM
+          const addtlRegion = applyWatershedBreadcrumb(feature, bounds, map.getZoom())
 
-          const addtlRegion: RegionOption | undefined = getRegionByLabel(countryOrRegion)
-          const subRegionWithUpdatedConfig: RegionOption = {
-            id: 'watershed',
-            regionType: 'watershed',
-            label: 'Watershed',
-            centerCoord: bounds.getCenter(),
-            zoomLevel: map.getZoom(),
-            grouping: 3,
-          }
-
-          // Breadcrumb: Global > [Country] > Watershed
-          // Country is omitted if it can't be determined from the feature
-          const updatedRegions: RegionOption[] = [defaultGlobalRegionOption]
-          if (addtlRegion) {
-            updatedRegions.push(addtlRegion)
-          }
-          updatedRegions.push(subRegionWithUpdatedConfig)
-
-          setBreadcrumb(updatedRegions)
           if (addtlRegion) {
             onRegionChange(addtlRegion)
           }
-
-          // Sync watershed ID to URL
           const featureWatershedId = feature.id != null ? String(feature.id) : null
           onWatershedChange(featureWatershedId)
 
-          // Skip fitBounds when restoring from URL with explicit lat/lng/zoom
-          if (!options?.skipFitBounds) {
-            const config = isDesktopWidth ? mapFitBoundsDesktopConfig : mapFitBoundsMobileConfig
-            map.fitBounds(bounds, {
-              padding: config.padding,
-              maxZoom: config.maxZoom,
-              duration: 800,
-            })
-          }
+          const config = isDesktopWidth ? mapFitBoundsDesktopConfig : mapFitBoundsMobileConfig
+          map.fitBounds(bounds, {
+            padding: config.padding,
+            maxZoom: config.maxZoom,
+            duration: 800,
+          })
         }
       }
     },
-    [isDesktopWidth, setBreadcrumb, setSelectedFeature, onRegionChange, onWatershedChange],
+    [isDesktopWidth, applyWatershedBreadcrumb, setSelectedFeature, onRegionChange, onWatershedChange],
   )
 
   const polygonHoverHandler = useMemo(() => createPolygonHoverHandler(polygonHoverRef), [])
@@ -310,17 +310,6 @@ export default function BaseMap({
       maplibregl.removeProtocol('cog')
     }
   }, [])
-
-  useEffect(() => {
-    const map = mapRef.current?.getMap()
-
-    const jumpOptions = {
-      center: selectedRegion.centerCoord,
-      zoom: selectedRegion.zoomLevel,
-      bearing: 0,
-    }
-    map?.jumpTo(jumpOptions)
-  }, [selectedRegion])
 
   useEffect(() => {
     if (!isMapLoaded) {
@@ -363,9 +352,15 @@ export default function BaseMap({
     }
   }, [selectedFeature, isMapLoaded, watershedLayer])
 
-  // Watershed restoration from URL
+  // Restore watershed selection from URL. Runs on initial page load and
+  // when the watershed param changes (e.g. browser back/forward).
+  // Skips when the polygon was just clicked (polygonClickRef already matches).
   useEffect(() => {
-    if (!isMapLoaded || !initialWatershedId || !watershedLayer) {
+    if (!isMapLoaded || !watershedLayer) {
+      return undefined
+    }
+
+    if (!watershedId) {
       return undefined
     }
 
@@ -376,16 +371,28 @@ export default function BaseMap({
 
     // watershed_id is numeric in tile data. Parse to number to match
     // the promoted feature ID used by MapLibre for setFeatureState.
-    const featureId = isNaN(Number(initialWatershedId))
-      ? initialWatershedId
-      : Number(initialWatershedId)
+    const featureId = isNaN(Number(watershedId)) ? watershedId : Number(watershedId)
 
-    return querySourceFeatureWhenReady(
+    // User just clicked this polygon — it's already selected, skip restoration.
+    if (polygonClickRef.current === featureId) {
+      return undefined
+    }
+
+    // Clear the previous selection before restoring the new one.
+    clearPolygonSelect(map, polygonClickRef, watershedLayer)
+
+    let cancelled = false
+
+    const cancelQuery = querySourceFeatureWhenReady(
       map,
       watershedLayer.sourceId,
       watershedLayer.sourceFileName,
-      ['==', ['get', 'watershed_id'], Number(initialWatershedId)],
+      ['==', ['get', 'watershed_id'], Number(watershedId)],
       (feature) => {
+        if (cancelled) {
+          return
+        }
+
         if (!feature) {
           onWatershedChange(null)
           return
@@ -400,15 +407,20 @@ export default function BaseMap({
         setPolygonSelect(map, polygonClickRef, watershedLayer, featureId)
 
         const bounds = calculateFeatureBounds(feature)
-        handleFeatureSelect(feature, bounds, {
-          skipFitBounds: hasExplicitViewState,
-        })
+        setSelectedFeature(feature)
+        applyWatershedBreadcrumb(feature, bounds, map.getZoom())
+        onWatershedRestored?.(bounds)
       },
     )
-    // handleFeatureSelect and onWatershedChange intentionally omitted
-    // initialWatershedId is stable (captured once at mount) so this effect only runs once when the map loads.
+
+    return () => {
+      cancelled = true
+      cancelQuery()
+    }
+    // onWatershedChange intentionally omitted — stable callback whose
+    // inclusion would cause unnecessary re-triggers.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isMapLoaded, initialWatershedId, watershedLayer, hasExplicitViewState])
+  }, [isMapLoaded, watershedId, watershedLayer, setSelectedFeature, applyWatershedBreadcrumb, onWatershedRestored])
 
   const benthicFillColors = useMapStore((s) => s.benthicMapSubLayerColors)
   const benthicSubLayerFillExpression = useMemo(

--- a/src/components/BaseMap/BaseMap.tsx
+++ b/src/components/BaseMap/BaseMap.tsx
@@ -273,7 +273,13 @@ export default function BaseMap({
         }
       }
     },
-    [isDesktopWidth, applyWatershedBreadcrumb, setSelectedFeature, onRegionChange, onWatershedChange],
+    [
+      isDesktopWidth,
+      applyWatershedBreadcrumb,
+      setSelectedFeature,
+      onRegionChange,
+      onWatershedChange,
+    ],
   )
 
   const polygonHoverHandler = useMemo(() => createPolygonHoverHandler(polygonHoverRef), [])
@@ -420,7 +426,14 @@ export default function BaseMap({
     // onWatershedChange intentionally omitted — stable callback whose
     // inclusion would cause unnecessary re-triggers.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isMapLoaded, watershedId, watershedLayer, setSelectedFeature, applyWatershedBreadcrumb, onWatershedRestored])
+  }, [
+    isMapLoaded,
+    watershedId,
+    watershedLayer,
+    setSelectedFeature,
+    applyWatershedBreadcrumb,
+    onWatershedRestored,
+  ])
 
   const benthicFillColors = useMapStore((s) => s.benthicMapSubLayerColors)
   const benthicSubLayerFillExpression = useMemo(

--- a/src/components/BaseMap/BaseMap.tsx
+++ b/src/components/BaseMap/BaseMap.tsx
@@ -387,6 +387,7 @@ export default function BaseMap({
     // Clear the previous selection before restoring the new one.
     clearPolygonSelect(map, polygonClickRef, watershedLayer)
 
+    // Prevents cleanup's cancelQuery() from triggering onWatershedChange(null).
     let cancelled = false
 
     const cancelQuery = querySourceFeatureWhenReady(

--- a/src/components/MapContainer/MapContainer.tsx
+++ b/src/components/MapContainer/MapContainer.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useState, useMemo, useRef } from 'react'
-import { useSearchParams } from 'react-router'
+import { useNavigationType, useSearchParams } from 'react-router'
+import { LngLatBounds } from 'maplibre-gl'
 import LayersDrawer from '../LayersDrawer/LayersDrawer'
 import BaseMap from '../BaseMap/BaseMap'
 import RegionSelect from '../RegionSelect/RegionSelect'
@@ -17,12 +18,16 @@ import {
   getValidWatershed,
   getValidZoom,
 } from '../../utils/routeUtils'
+import { mapFitBoundsDesktopConfig, mapFitBoundsMobileConfig } from '../../constants'
+import useResponsive from '../../hooks/useResponsive'
 import { useMapStore } from '../../stores/mapStore'
 import { useSelectedFeatureStore } from '../../stores/selectedFeatureStore'
 import { defaultGlobalRegionOption } from '../../data/regionData'
 
 export default function MapContainer() {
   const [searchParams, setSearchParams] = useSearchParams()
+  const navigationType = useNavigationType()
+  const { isDesktopWidth } = useResponsive()
   const year = searchParams.get('year')
   const selectedYear = getValidYear(year)
   const normalizedYearParam = selectedYear.toString()
@@ -38,9 +43,8 @@ export default function MapContainer() {
   const normalizedLayersParam = selectedLayers.length > 0 ? selectedLayers.join(',') : 'none'
   const shouldSyncLayersParam = layersParam !== normalizedLayersParam
 
-  // Captured once at mount — only used for initial restoration on page load.
-  // Clicks update the URL via handleWatershedChange but don't re-trigger restoration.
-  const [initialWatershedId] = useState(() => getValidWatershed(searchParams.get('watershed')))
+  const watershedParam = searchParams.get('watershed')
+  const watershedId = getValidWatershed(watershedParam)
 
   // TODO: Handle dispersal-point URL param (C152)
 
@@ -61,6 +65,7 @@ export default function MapContainer() {
   const turnOffSedExportSubLayerFills = useMapStore((state) => state.turnOffSedExportSubLayerFills)
   const clearSelectedFeature = useSelectedFeatureStore((s) => s.clearSelectedFeature)
   const latestSearchParamsRef = useRef(new URLSearchParams(searchParams))
+  const hasRestoredWatershedRef = useRef(false)
 
   useEffect(() => {
     latestSearchParamsRef.current = new URLSearchParams(searchParams)
@@ -118,8 +123,7 @@ export default function MapContainer() {
     shouldSyncLayersParam,
   ])
 
-  const watershedParam = searchParams.get('watershed')
-
+  // Sync local region/breadcrumb state when URL params change.
   useEffect(() => {
     setSelectedRegion(initialRegion)
     if (!watershedParam) {
@@ -128,6 +132,39 @@ export default function MapContainer() {
       )
     }
   }, [initialRegion, watershedParam])
+
+  // Restore map position on browser back/forward (POP). PUSH/REPLACE are
+  // handled by calling code (fitBounds for polygon clicks, jumpToRegion for
+  // dropdown). On initial page load navigationType is also POP, but
+  // mapReference is null so jumpTo is a no-op — initialViewState handles that.
+  useEffect(() => {
+    if (navigationType !== 'POP') {
+      return
+    }
+
+    const map = useMapStore.getState().mapReference?.getMap()
+    // Read lat/lng/zoom from searchParams at execution time rather than
+    // from render-scope variables — avoids re-running this effect on every
+    // map pan (handleMapMoveEnd writes lat/lng/zoom to the URL continuously).
+    const currentParams = latestSearchParamsRef.current
+    const { lat: popLat, lng: popLng } = getValidLatLng(
+      currentParams.get('lat'),
+      currentParams.get('lng'),
+    )
+    const popZoom = getValidZoom(currentParams.get('zoom'))
+    if (popLat !== null && popLng !== null && popZoom !== null) {
+      map?.jumpTo({ center: [popLng, popLat], zoom: popZoom, bearing: 0 })
+    } else {
+      map?.jumpTo({
+        center: initialRegion.centerCoord,
+        zoom: initialRegion.zoomLevel,
+        bearing: 0,
+      })
+    }
+    if (!watershedParam) {
+      clearSelectedFeature()
+    }
+  }, [initialRegion, watershedParam, navigationType, clearSelectedFeature])
 
   const handleRegionChange = useCallback(
     (region: RegionOption) => {
@@ -159,6 +196,33 @@ export default function MapContainer() {
       )
     },
     [updateSearchParams],
+  )
+
+  // Called by BaseMap when the watershed restoration effect finds the
+  // feature in the tile data. Decides whether to animate the map to it.
+  // On initial page load without explicit lat/lng/zoom: fitBounds so the
+  // user sees the watershed. On POP (back/forward) or when the URL already
+  // has a view state: skip, because the map is already positioned.
+  const handleWatershedRestored = useCallback(
+    (bounds: LngLatBounds) => {
+      if (hasRestoredWatershedRef.current || hasExplicitViewState) {
+        return
+      }
+      hasRestoredWatershedRef.current = true
+
+      const map = useMapStore.getState().mapReference?.getMap()
+      if (!map) {
+        return
+      }
+
+      const config = isDesktopWidth ? mapFitBoundsDesktopConfig : mapFitBoundsMobileConfig
+      map.fitBounds(bounds, {
+        padding: config.padding,
+        maxZoom: config.maxZoom,
+        duration: 800,
+      })
+    },
+    [hasExplicitViewState, isDesktopWidth],
   )
 
   // Used by the region dropdown and breadcrumb navigation.
@@ -276,12 +340,11 @@ export default function MapContainer() {
       <BaseMap
         mapLayers={urlSyncedMapLayers}
         sedExportSubLayerValue={subSedLayerValue}
-        selectedRegion={selectedRegion}
         onRegionChange={handleRegionChange}
         onWatershedChange={handleWatershedChange}
-        initialWatershedId={initialWatershedId}
-        hasExplicitViewState={hasExplicitViewState}
+        watershedId={watershedId}
         setBreadcrumb={setBreadcrumb}
+        onWatershedRestored={handleWatershedRestored}
         initialViewState={{
           longitude: lng ?? selectedRegion.centerCoord.lng,
           latitude: lat ?? selectedRegion.centerCoord.lat,

--- a/src/components/RegionSelect/RegionSelect.tsx
+++ b/src/components/RegionSelect/RegionSelect.tsx
@@ -3,7 +3,9 @@ import { useTranslation } from 'react-i18next'
 import styles from './RegionSelect.module.scss'
 import { RegionOption } from '../../types/RegionDataTypes'
 import _ from 'lodash'
-import { defaultGlobalRegionOption, regionOptions } from '../../data/regionData'
+import { defaultGlobalRegionOption, GLOBAL_DATA_BOUNDS, regionOptions } from '../../data/regionData'
+import { mapFitBoundsDesktopConfig, mapFitBoundsMobileConfig } from '../../constants'
+import useResponsive from '../../hooks/useResponsive'
 import { MenuItem, Select } from '@mui/material'
 import ChevronRightIcon from '@mui/icons-material/ChevronRight'
 import Box from '@mui/material/Box'
@@ -26,6 +28,7 @@ export default function RegionSelect({
 }: RegionSelectProps) {
   const { t } = useTranslation()
   const mapRef = useMapStore((s) => s.mapReference)
+  const { isDesktopWidth } = useResponsive()
 
   const prepBreadcrumb = (region: RegionOption) => {
     const selectedOptions = [region]
@@ -35,15 +38,24 @@ export default function RegionSelect({
     setBreadcrumb(selectedOptions)
   }
   const jumpToRegion = (region: RegionOption) => {
-    // no jump on global click
-    if (region.grouping > 0) {
-      if (mapRef && mapRef.getMap) {
-        mapRef.getMap().jumpTo({
-          center: region.centerCoord,
-          zoom: region.zoomLevel,
-          bearing: 0,
-        })
-      }
+    if (!mapRef?.getMap) {
+      return
+    }
+    const map = mapRef.getMap()
+
+    if (region.grouping === 0) {
+      const config = isDesktopWidth ? mapFitBoundsDesktopConfig : mapFitBoundsMobileConfig
+      map.fitBounds(GLOBAL_DATA_BOUNDS, {
+        padding: config.padding,
+        maxZoom: config.maxZoom,
+        duration: 800,
+      })
+    } else {
+      map.jumpTo({
+        center: region.centerCoord,
+        zoom: region.zoomLevel,
+        bearing: 0,
+      })
     }
   }
 
@@ -83,9 +95,7 @@ export default function RegionSelect({
   }
 
   const updateRegion = (region: RegionOption) => {
-    if (region.grouping > 0) {
-      jumpToRegion(region)
-    }
+    jumpToRegion(region)
     onRegionChange(region)
     prepBreadcrumb(region)
   }

--- a/src/data/regionData.ts
+++ b/src/data/regionData.ts
@@ -1,4 +1,4 @@
-import { LngLat } from 'maplibre-gl'
+import { LngLat, LngLatBounds } from 'maplibre-gl'
 import { RegionOption } from '../types/RegionDataTypes'
 
 export const defaultGlobalRegionOption: RegionOption = {
@@ -9,6 +9,9 @@ export const defaultGlobalRegionOption: RegionOption = {
   zoomLevel: 6,
   grouping: 0,
 }
+
+/** Bounding box that frames all current data (Fiji + Solomon Islands). */
+export const GLOBAL_DATA_BOUNDS = new LngLatBounds([152, -23], [182, -1])
 
 /** MVP: Starts with just the two countries & one region */
 export const regionOptions: RegionOption[] = [

--- a/src/data/regionData.ts
+++ b/src/data/regionData.ts
@@ -10,7 +10,10 @@ export const defaultGlobalRegionOption: RegionOption = {
   grouping: 0,
 }
 
-/** Bounding box that frames all current data (Fiji + Solomon Islands). */
+/**
+ * Bounding box that frames all current data (Fiji + Solomon Islands).
+ * NE longitude > 180 to avoid wrapping the wrong way around the antimeridian.
+ */
 export const GLOBAL_DATA_BOUNDS = new LngLatBounds([152, -23], [182, -1])
 
 /** MVP: Starts with just the two countries & one region */

--- a/src/utils/mapUtils.ts
+++ b/src/utils/mapUtils.ts
@@ -31,6 +31,12 @@ export function calculateFeatureBounds(feature: MapGeoJSONFeature): LngLatBounds
     geometry.coordinates[0].forEach(([lng, lat]) => {
       bounds.extend([lng, lat])
     })
+  } else if (geometry.type === 'MultiPolygon') {
+    geometry.coordinates.forEach((polygon) => {
+      polygon[0].forEach(([lng, lat]) => {
+        bounds.extend([lng, lat])
+      })
+    })
   }
 
   return bounds


### PR DESCRIPTION
## Summary

- BaseMap had a `useEffect` that jumped to the region center whenever `selectedRegion` changed, overriding the `fitBounds` animation from the click handler. Removed it — each code path now owns its own map positioning: clicks `fitBounds`, dropdown uses `jumpToRegion`, browser back/forward uses a POP-specific effect in MapContainer.
- Watershed restoration is now reactive to URL changes so back/forward restores the polygon highlight and breadcrumb. BaseMap notifies MapContainer via `onWatershedRestored`; MapContainer decides whether to `fitBounds`, eliminating `hasExplicitViewState`, `skipFitBounds`, and `skipUrlUpdate` from BaseMap.
- Split region-sync from the POP handler and read lat/lng/zoom inside the effect body to avoid re-running on every map pan. Extracted `applyWatershedBreadcrumb` so click and restoration share breadcrumb logic without routing restoration through `handleFeatureSelect`.
- Added MultiPolygon support in `calculateFeatureBounds` and a cancellation flag to restoration effect cleanup.
- Selecting "Global" in the breadcrumb or dropdown now animates the map to fit the global data extent (Fiji + Solomon Islands) using `fitBounds` with responsive padding, rather than doing nothing.

## Testing steps

1. **Cross-region watershed click (core fix)**
   - Click a watershed polygon in a region different from the currently selected one
   - Map should fit to the watershed, not snap to the region center

2. **Page load with watershed in URL**
   - Highlight a watershed and refresh the page
   - Map highlights the watershed and fits extent to it

3. **Browser back/forward**
   - Click a watershed, then press Back
   - Map returns to previous position, watershed clears
   - Press Forward
   - Watershed highlight and breadcrumb restore, map uses saved position (no re-fit)

4. **Dropdown/breadcrumb clears watershed**
   - With a watershed selected, pick a region from the dropdown or click a breadcrumb
   - Watershed clears, map jumps to region center

5. **Global zoom**
   - From a zoomed-in view (e.g. a watershed or country), click "Global" in the breadcrumb or select it from the dropdown
   - Map should animate to show the full data extent (both Fiji and Solomon Islands)

6. **General — no regressions**
   - Pan, zoom, toggle layers, change year
   - Everything works as before or better

## Every PR

Before merging, the developer of this pull request has checked the following:

- [ ] Changes have been tested locally without errors
- [ ] Lint has run and any errors have been resolved
- [ ] Prettier has run on any changed files
- [ ] Storybook stories have run and any errors have been resolved
- [ ] Pre-existing unit tests have run and passed
  - [ ] Unit tests have been added or updated, where possible, to prevent future regressions

## Post-Merge

- [ ] Code has merged and build success is confirmed in 'Actions'
- [ ] The corresponding Trello ticket has moved to the appropriate list (likely User-QA)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved browser back/forward navigation to preserve map view state
  * Enhanced region selection with responsive navigation controls
  * Streamlined watershed boundary adjustment workflow

* **Bug Fixes**
  * Fixed support for complex multi-polygon geographic regions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->