### PR TITLE
feat: [C126] Add ecosystem extent chart data from PMTiles + update boundary sources

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -7,11 +7,11 @@ if (!coralAtlasAppId) {
 /******MAP LAYERS******/
 /* Boundary Layers - always on */
 export const REGIONS_PMTILES_URL =
-  'https://gpw-coastal-pollution-model-data-public-0001.s3.ap-southeast-2.amazonaws.com/app/regions/regions.pmtiles'
+  'https://d2uu99zl9amnvy.cloudfront.net/assets/meow_realms/meow_realms/visual_regions.pmtiles'
 export const COUNTRIES_PMTILES_URL =
-  'https://gpw-coastal-pollution-model-data-public-0001.s3.ap-southeast-2.amazonaws.com/app/countries/countries.pmtiles'
+  'https://d2uu99zl9amnvy.cloudfront.net/assets/countries/countries/visual_countries.pmtiles'
 export const WATERSHED_PMTILES_URL =
-  'https://gpw-coastal-pollution-model-data-public-0001.s3.ap-southeast-2.amazonaws.com/app/watersheds/watersheds.pmtiles'
+  'https://d2uu99zl9amnvy.cloudfront.net/assets/watersheds/watersheds/visual_watersheds.pmtiles'
 
 /* Land Use Land Cover Layers */
 export const LULC_2000_URL =

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -7,11 +7,11 @@ if (!coralAtlasAppId) {
 /******MAP LAYERS******/
 /* Boundary Layers - always on */
 export const REGIONS_PMTILES_URL =
-  'https://d2uu99zl9amnvy.cloudfront.net/assets/meow_realms/meow_realms/visual_regions.pmtiles'
+  'https://d2uu99zl9amnvy.cloudfront.net/assets/gpw_meow_realms/gpw_meow_realms/visual_regions.pmtiles'
 export const COUNTRIES_PMTILES_URL =
-  'https://d2uu99zl9amnvy.cloudfront.net/assets/countries/countries/visual_countries.pmtiles'
+  'https://d2uu99zl9amnvy.cloudfront.net/assets/gpw_countries/gpw_countries/visual_countries.pmtiles'
 export const WATERSHED_PMTILES_URL =
-  'https://d2uu99zl9amnvy.cloudfront.net/assets/watersheds/watersheds/visual_watersheds.pmtiles'
+  'https://d2uu99zl9amnvy.cloudfront.net/assets/gpw_watersheds/gpw_watersheds/visual_watersheds.pmtiles'
 
 /* Land Use Land Cover Layers */
 export const LULC_2000_URL =

--- a/src/data/mapData.ts
+++ b/src/data/mapData.ts
@@ -224,7 +224,7 @@ export const layers: LayerInfo[] = [
     outlineStyle: false,
     parentLayerType: 'boundaries',
     sourceId: 'regions_src',
-    sourceFileName: 'regions',
+    sourceFileName: 'data',
     title: 'boundary_map_layers.regional_boundaries',
   },
   {
@@ -235,7 +235,7 @@ export const layers: LayerInfo[] = [
     outlineColor: '#FF0000',
     parentLayerType: 'boundaries',
     sourceId: 'countries_src',
-    sourceFileName: 'countries',
+    sourceFileName: 'data',
     title: 'boundary_map_layers.country_boundaries',
   },
   {
@@ -258,7 +258,7 @@ export const layers: LayerInfo[] = [
     outlineColor: '#000',
     parentLayerType: 'boundaries',
     sourceId: 'watershed_src',
-    sourceFileName: 'watersheds',
+    sourceFileName: 'data',
     title: 'boundary_map_layers.watershed_boundaries',
   },
 ]

--- a/src/tests/chartUtils.test.ts
+++ b/src/tests/chartUtils.test.ts
@@ -13,6 +13,11 @@ const groupedProperties: LulcAndSedimentSeriesData = {
     mixed_forest: { '2015': 4 },
     shrubland_grassland: { '2020': 6 },
   },
+  ecosystem_extent_exposed: {
+    reef_extent: {},
+    coral_algae: {},
+    seagrass: {},
+  },
   sediment_load_historical: {
     sediment: {},
   },
@@ -34,6 +39,11 @@ const emptyChartSeriesData: LulcAndSedimentSeriesData = {
     high_canopy_forest: {},
     mixed_forest: {},
     shrubland_grassland: {},
+  },
+  ecosystem_extent_exposed: {
+    reef_extent: {},
+    coral_algae: {},
+    seagrass: {},
   },
   sediment_load_historical: {
     sediment: {},

--- a/src/utils/chartUtils.ts
+++ b/src/utils/chartUtils.ts
@@ -46,6 +46,11 @@ export interface LulcAndSedimentSeriesData {
     mixed_forest: object
     shrubland_grassland: object
   }
+  ecosystem_extent_exposed: {
+    reef_extent: object
+    coral_algae: object
+    seagrass: object
+  }
   sediment_load_historical: {
     sediment: object
   }
@@ -61,6 +66,11 @@ export const getBoundaryFileChartData = (pointProperties): LulcAndSedimentSeries
       high_canopy_forest: {},
       mixed_forest: {},
       shrubland_grassland: {},
+    },
+    ecosystem_extent_exposed: {
+      reef_extent: {},
+      coral_algae: {},
+      seagrass: {},
     },
     sediment_load_historical: {
       sediment: {},
@@ -101,7 +111,17 @@ export const getBoundaryFileChartData = (pointProperties): LulcAndSedimentSeries
         case 'Shrub_Grass_pct_':
           chartSeriesData.land_use_historical.shrubland_grassland[year] = val
           break
+        case 'reef_exposed_':
+          chartSeriesData.ecosystem_extent_exposed.reef_extent[year] = val
+          break
+        case 'coralg_exposed_':
+          chartSeriesData.ecosystem_extent_exposed.coral_algae[year] = val
+          break
+        case 'seag_exposed_':
+          chartSeriesData.ecosystem_extent_exposed.seagrass[year] = val
+          break
         case 'sed_export_':
+        case 'total_sed_load_':
           chartSeriesData.sediment_load_historical.sediment[year] = val
           break
       }
@@ -200,10 +220,12 @@ export const mapChartConfigToData = (
       ? `${chartProperties.tracePrefix}.${category}`
       : `${category}`
     const traceName: string = i18next.t(prefixedTrace)
-    const hoverTemplate =
-      chartName === 'sediment_load_historical'
-        ? `${xAxisTitle}: %{x}<br />${traceName}: %{y:.2f}T<extra></extra>`
-        : `${xAxisTitle}: %{x}<br />${traceName}: %{y}%<extra></extra>`
+    const unitSuffix: Record<string, string> = {
+      sediment_load_historical: ':.2f}T',
+      ecosystem_extent_exposed: '}ha',
+    }
+    const yFormat = unitSuffix[chartName] ?? '}%'
+    const hoverTemplate = `${xAxisTitle}: %{x}<br />${traceName}: %{y${yFormat}<extra></extra>`
 
     chartSeriesData.push({
       type: 'bar',
@@ -234,17 +256,17 @@ export const buildChartDataFromProperties = (
 ): ChartProperties[] | null => {
   const chartSeriesData = getBoundaryFileChartData(properties)
 
-  const hasData = Object.values(chartSeriesData).some((series) =>
+  const seriesWithData = Object.entries(chartSeriesData).filter(([, series]) =>
     Object.values(series as Record<string, object>).some(
       (yearData) => Object.keys(yearData).length > 0,
     ),
   )
-  if (!hasData) {
+  if (!seriesWithData.length) {
     return null
   }
 
-  return Object.entries(chartSeriesData).map((dataSet) =>
-    mapChartConfigToData(dataSet[1] as ChartData, dataSet[0] as ChartSeriesName),
+  return seriesWithData.map(([name, data]) =>
+    mapChartConfigToData(data as ChartData, name as ChartSeriesName),
   )
 }
 

--- a/src/utils/pmtilesUtils.ts
+++ b/src/utils/pmtilesUtils.ts
@@ -18,7 +18,7 @@ function getPMTiles(url: string): PMTiles {
 export const boundarySourceConfig: Partial<
   Record<RegionType, { url: string; sourceLayer: string; filterProp: string }>
 > = {
-  region: { url: REGIONS_PMTILES_URL, sourceLayer: 'data', filterProp: 'name' },
+  region: { url: REGIONS_PMTILES_URL, sourceLayer: 'data', filterProp: 'REALM' },
   country: { url: COUNTRIES_PMTILES_URL, sourceLayer: 'data', filterProp: 'TERRITORY1' },
 }
 

--- a/src/utils/pmtilesUtils.ts
+++ b/src/utils/pmtilesUtils.ts
@@ -18,8 +18,8 @@ function getPMTiles(url: string): PMTiles {
 export const boundarySourceConfig: Partial<
   Record<RegionType, { url: string; sourceLayer: string; filterProp: string }>
 > = {
-  region: { url: REGIONS_PMTILES_URL, sourceLayer: 'regions', filterProp: 'name' },
-  country: { url: COUNTRIES_PMTILES_URL, sourceLayer: 'countries', filterProp: 'TERRITORY1' },
+  region: { url: REGIONS_PMTILES_URL, sourceLayer: 'data', filterProp: 'name' },
+  country: { url: COUNTRIES_PMTILES_URL, sourceLayer: 'data', filterProp: 'TERRITORY1' },
 }
 
 /**


### PR DESCRIPTION
**Summary**
- Switch boundary PMTiles (regions, countries, watersheds) to CloudFront/MERMAID Covariates/Prescient URLs and update all source layer names to 'data'.
- Parse `reef_exposed`, `coralg_exposed`, and `seag_exposed` fields from watershed PMTiles into the ecosystem extent exposed chart.
- Support both `sed_export` and `total_sed_load` field names for sediment data across boundary types (currently they're mixed)
- Hide charts that have no data for the selected boundary rather than showing empty charts.

**Caveats - pending data updates**
The following known gaps in the new PMTiles are waiting on a data refresh and will resolve once updated:
- Breadcrumb country/region missing for watershed clicks - `visual_watersheds.pmtiles` no longer carries `TERRITORY1` / `UN_TER1` / `REALM`, so clicking a watershed shows `Global > Watershed` instead of `Global > Fiji > Watershed`. Will work again once the watershed file is has these fields restored.
- Ecosystem extent chart not shown at region / country level - `visual_regions.pmtiles` and `visual_countries.pmtiles` are missing `reef_exposed_YYYY`, `coralg_exposed_YYYY`, and `seag_exposed_YYYY`. The chart renders correctly for watersheds; it will also appear at region and country once those fields are added.

**Note on sediment field naming

## Every PR

Before merging, the developer of this pull request has checked the following:

- [ ] Changes have been tested locally without errors
- [ ] Lint has run and any errors have been resolved
- [ ] Prettier has run on any changed files
- [ ] Storybook stories have run and any errors have been resolved
- [ ] Pre-existing unit tests have run and passed
  - [ ] Unit tests have been added or updated, where possible, to prevent future regressions

## Post-Merge

- [ ] Code has merged and build success is confirmed in 'Actions'
- [ ] The corresponding Trello ticket has moved to the appropriate list (likely User-QA)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ecosystem extent data visualization including reef extent, coral algae, and seagrass metrics.
  * Enhanced chart hover text formatting for improved data readability.

* **Chores**
  * Updated map data source infrastructure for improved performance and reliability.
  * Refined data fetching and filtering logic for chart generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->