### PR TITLE
feat: [C141] Group region dropdown by type with section headers

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "lint": "tsc && eslint .",
     "preview": "vite preview",
     "test": "jest --setupFilesAfterEnv=./src/tests/setupTests.ts",
+    "test:stories": "vitest --project=storybook --run",
+    "test:all": "yarn test && yarn test:stories",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "prepare": "husky"

--- a/src/components/BaseMap/BaseMap.tsx
+++ b/src/components/BaseMap/BaseMap.tsx
@@ -189,7 +189,6 @@ const applyPlumeStats = ({
     label: 'Plume',
     centerCoord: new LngLat(point.lng, point.lat),
     zoomLevel: map.getZoom(),
-    grouping: 3,
   })
 
   setBreadcrumb(breadcrumb)
@@ -447,7 +446,6 @@ export default function BaseMap({
             label: 'Watershed',
             centerCoord: bounds.getCenter(),
             zoomLevel: map.getZoom(),
-            grouping: 3,
           })
 
           setBreadcrumb(breadcrumb)

--- a/src/components/MapContainer/MapContainer.tsx
+++ b/src/components/MapContainer/MapContainer.tsx
@@ -69,7 +69,9 @@ export default function MapContainer() {
   const [subSedLayerValue, setSubLayerValue] = useState<'pixel' | 'watershed'>('pixel')
   const [selectedRegion, setSelectedRegion] = useState<RegionOption>(initialRegion)
   const [breadcrumb, setBreadcrumb] = useState<RegionOption[]>(
-    initialRegion.grouping > 0 ? [defaultGlobalRegionOption, initialRegion] : [initialRegion],
+    initialRegion.regionType !== 'global'
+      ? [defaultGlobalRegionOption, initialRegion]
+      : [initialRegion],
   )
 
   const latestSearchParamsRef = useRef(new URLSearchParams(searchParams))
@@ -134,7 +136,9 @@ export default function MapContainer() {
     setSelectedRegion(initialRegion)
     if (!watershedParam) {
       setBreadcrumb(
-        initialRegion.grouping > 0 ? [defaultGlobalRegionOption, initialRegion] : [initialRegion],
+        initialRegion.regionType !== 'global'
+          ? [defaultGlobalRegionOption, initialRegion]
+          : [initialRegion],
       )
     }
   }, [initialRegion, watershedParam])

--- a/src/components/RegionSelect/RegionSelect.module.scss
+++ b/src/components/RegionSelect/RegionSelect.module.scss
@@ -139,19 +139,8 @@
   @include muiComponents.muiSelectMenuItem;
 }
 
-// To be implemented with regional grouping headers
-//.group-header {
-//  position: sticky;
-//  top: -8px;
-//  font-weight: theme.$semiBold;
-//  padding: theme.$spacingSmall theme.$spacingMedium;
-//  border-bottom: 1px solid theme.$secondary;
-//  font-size: theme.$textSizeSmall;
-//}
-//
-//.group-list {
-//  padding: 0;
-//  margin: 0;
-//  list-style: none;
-//  font-size: theme.$textSizeSmall;
-//}
+.group-header {
+  color: theme.$textColor;
+  font-size: theme.$textSizeMedium;
+  font-weight: theme.$semiBold;
+}

--- a/src/components/RegionSelect/RegionSelect.stories.tsx
+++ b/src/components/RegionSelect/RegionSelect.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import RegionSelect from './RegionSelect'
-import { expect, userEvent } from 'storybook/test'
+import { expect, fn, userEvent, within } from 'storybook/test'
 import { defaultGlobalRegionOption, regionOptions } from '../../data/regionData'
 
 const meta: Meta<typeof RegionSelect> = {
@@ -24,6 +24,54 @@ export const ShortBreadcrumb: Story = {
     const input = canvas.getByRole('combobox')
     await expect(input).toBeInTheDocument()
     await userEvent.click(input)
+
+    // Dropdown renders in a portal, so query the document body, not the canvas.
+    const listbox = within(document.body).getByRole('listbox')
+
+    await expect(within(listbox).getByText('All Data')).toBeInTheDocument()
+    await expect(within(listbox).getByText('Regions with Coral Reefs')).toBeInTheDocument()
+    await expect(within(listbox).getByText('Countries with Coral Reefs')).toBeInTheDocument()
+
+    await expect(within(listbox).getByText('Global')).toBeInTheDocument()
+    await expect(within(listbox).getByText('Fiji')).toBeInTheDocument()
+    await expect(within(listbox).getByText('Solomon Islands')).toBeInTheDocument()
+    await expect(within(listbox).getByText('Central Indo-Pacific')).toBeInTheDocument()
+
+    await expect(within(listbox).queryByText('Watershed')).toBeNull()
+    await expect(within(listbox).queryByText('Plume')).toBeNull()
+  },
+}
+
+export const SelectingOptionFiresChange: Story = {
+  args: {
+    breadcrumb: [defaultGlobalRegionOption],
+    setBreadcrumb: fn(),
+    selectedRegion: defaultGlobalRegionOption,
+    onRegionChange: fn(),
+  },
+  play: async ({ canvas, args }) => {
+    await userEvent.click(canvas.getByRole('combobox'))
+    const listbox = within(document.body).getByRole('listbox')
+    await userEvent.click(within(listbox).getByText('Fiji'))
+
+    const fiji = regionOptions.find((r) => r.id === 'fiji')
+    await expect(args.onRegionChange).toHaveBeenCalledWith(fiji)
+  },
+}
+
+export const SubheaderClickIsNoop: Story = {
+  args: {
+    breadcrumb: [defaultGlobalRegionOption],
+    setBreadcrumb: fn(),
+    selectedRegion: defaultGlobalRegionOption,
+    onRegionChange: fn(),
+  },
+  play: async ({ canvas, args }) => {
+    await userEvent.click(canvas.getByRole('combobox'))
+    const listbox = within(document.body).getByRole('listbox')
+    await userEvent.click(within(listbox).getByText('Countries with Coral Reefs'))
+
+    await expect(args.onRegionChange).not.toHaveBeenCalled()
   },
 }
 

--- a/src/components/RegionSelect/RegionSelect.tsx
+++ b/src/components/RegionSelect/RegionSelect.tsx
@@ -3,8 +3,8 @@ import { useTranslation } from 'react-i18next'
 import styles from './RegionSelect.module.scss'
 import { RegionOption } from '../../types/RegionDataTypes'
 import _ from 'lodash'
-import { defaultGlobalRegionOption, regionOptions } from '../../data/regionData'
-import { MenuItem, Select } from '@mui/material'
+import { defaultGlobalRegionOption, regionGroups, regionOptions } from '../../data/regionData'
+import { ListSubheader, MenuItem, Select } from '@mui/material'
 import ChevronRightIcon from '@mui/icons-material/ChevronRight'
 import Box from '@mui/material/Box'
 import { useMapStore } from '../../stores/mapStore'
@@ -29,14 +29,14 @@ export default function RegionSelect({
 
   const prepBreadcrumb = (region: RegionOption) => {
     const selectedOptions = [region]
-    if (region.grouping > 0) {
+    if (region.regionType !== 'global') {
       selectedOptions.unshift(defaultGlobalRegionOption)
     }
     setBreadcrumb(selectedOptions)
   }
   const jumpToRegion = (region: RegionOption) => {
     // no jump on global click
-    if (region.grouping > 0) {
+    if (region.regionType !== 'global') {
       if (mapRef && mapRef.getMap) {
         mapRef.getMap().jumpTo({
           center: region.centerCoord,
@@ -83,7 +83,7 @@ export default function RegionSelect({
   }
 
   const updateRegion = (region: RegionOption) => {
-    if (region.grouping > 0) {
+    if (region.regionType !== 'global') {
       jumpToRegion(region)
     }
     onRegionChange(region)
@@ -111,9 +111,15 @@ export default function RegionSelect({
           select: styles['MuiSelect-select'],
         }}
       >
-        {regionOptions.map((option) => {
-          return (
-            option.grouping <= 2 && (
+        {/* For each group, emit a header followed by its options as menu items.
+            flatMap keeps them as direct children of <Select> (required by MUI). */}
+        {regionGroups.flatMap(({ type, label }) => [
+          <ListSubheader key={`group-${type}`} className={styles['group-header']}>
+            {label}
+          </ListSubheader>,
+          ...regionOptions
+            .filter((opt) => opt.regionType === type)
+            .map((option) => (
               <MenuItem
                 className={styles['MuiMenuItem-root']}
                 key={_.kebabCase(option.label)}
@@ -121,9 +127,8 @@ export default function RegionSelect({
               >
                 {option.label}
               </MenuItem>
-            )
-          )
-        })}
+            )),
+        ])}
       </Select>
     </Box>
   )

--- a/src/data/regionData.ts
+++ b/src/data/regionData.ts
@@ -1,5 +1,11 @@
 import { LngLat } from 'maplibre-gl'
-import { RegionOption } from '../types/RegionDataTypes'
+import { RegionOption, RegionType } from '../types/RegionDataTypes'
+
+export const regionGroups: { type: RegionType; label: string }[] = [
+  { type: 'global', label: 'All Data' },
+  { type: 'region', label: 'Regions with Coral Reefs' },
+  { type: 'country', label: 'Countries with Coral Reefs' },
+]
 
 export const defaultGlobalRegionOption: RegionOption = {
   id: 'global',
@@ -7,7 +13,6 @@ export const defaultGlobalRegionOption: RegionOption = {
   label: 'Global',
   centerCoord: new LngLat(160.414413, -9.64571),
   zoomLevel: 6,
-  grouping: 0,
 }
 
 /** MVP: Starts with just the two countries & one region */
@@ -19,7 +24,6 @@ export const regionOptions: RegionOption[] = [
     label: 'Fiji',
     centerCoord: new LngLat(179.414413, -16.578193),
     zoomLevel: 8,
-    grouping: 2,
   },
   {
     id: 'solomon-islands',
@@ -27,7 +31,6 @@ export const regionOptions: RegionOption[] = [
     label: 'Solomon Islands',
     centerCoord: new LngLat(160.156194, -9.64571),
     zoomLevel: 8,
-    grouping: 2,
   },
   {
     id: 'central-indo-pacific',
@@ -35,7 +38,6 @@ export const regionOptions: RegionOption[] = [
     label: 'Central Indo-Pacific',
     centerCoord: new LngLat(150.95132012291594, -0.5972317458082159),
     zoomLevel: 3,
-    grouping: 1,
   },
   {
     id: 'watershed',
@@ -43,7 +45,6 @@ export const regionOptions: RegionOption[] = [
     label: 'Watershed',
     centerCoord: new LngLat(179.414413, -16.578193),
     zoomLevel: 8,
-    grouping: 3,
   },
   {
     id: 'plume',
@@ -51,6 +52,5 @@ export const regionOptions: RegionOption[] = [
     label: 'Plume',
     centerCoord: new LngLat(179.414413, -16.578193),
     zoomLevel: 8,
-    grouping: 3,
   },
 ]

--- a/src/types/RegionDataTypes.ts
+++ b/src/types/RegionDataTypes.ts
@@ -6,6 +6,5 @@ export interface RegionOption {
   label: string
   centerCoord: LngLat
   zoomLevel: number
-  grouping: number //0+, used to denote what level in breadcrumb hierarchy
 }
 export type RegionType = 'global' | 'watershed' | 'country' | 'region' | 'plume'


### PR DESCRIPTION
Add visual groupings to the region selector so it scales as more countries and regions are added. Groups derive from RegionOption.regionType
via a single regionGroups source of truth.

- Render a ListSubheader per group: All Data, Regions with Coral Reefs, Countries with Coral Reefs
- Drop the grouping: number field; hide watershed/plume implicitly via their absence from regionGroups
- Add Storybook interaction tests and test:stories / test:all scripts

## Every PR

Before merging, the developer of this pull request has checked the following:

- [ ] Changes have been tested locally without errors
- [ ] Lint has run and any errors have been resolved
- [ ] Prettier has run on any changed files
- [ ] Storybook stories have run and any errors have been resolved
- [ ] Pre-existing unit tests have run and passed
  - [ ] Unit tests have been added or updated, where possible, to prevent future regressions

## Post-Merge

- [ ] Code has merged and build success is confirmed in 'Actions'
- [ ] The corresponding Trello ticket has moved to the appropriate list (likely User-QA)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced region selection with improved group header styling and organization.

* **Bug Fixes**
  * Corrected global region handling in breadcrumb navigation logic.

* **Tests**
  * Added comprehensive test stories for region selection interactions and dropdown behavior.
  * New test scripts for automated story validation (`test:stories`, `test:all`).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->