### PR TITLE
feat: [C178] Add shoreline emphasis outline to basemap water layer

### DIFF
--- a/src/components/BaseMap/BaseMap.tsx
+++ b/src/components/BaseMap/BaseMap.tsx
@@ -46,6 +46,7 @@ import {
   setPolygonSelect,
   getAllYearZonalStats,
   buildBenthicFillExpression,
+  resolveBasemapBeforeId,
 } from '../../utils/mapUtils'
 import { SourceDataEvent } from '../../types/MapLayerErrorTypes'
 import { CircularProgress, Snackbar, SnackbarContent } from '@mui/material'
@@ -242,7 +243,7 @@ const handleMapClick = async (e: MapMouseEvent, clickParams: HandleMapClickParam
   })
 }
 
-function WatershedLayers({ layer, index }) {
+function WatershedLayers({ layer, index, beforeId }: { layer; index; beforeId?: string }) {
   return (
     <Source
       id={layer.sourceId}
@@ -257,7 +258,7 @@ function WatershedLayers({ layer, index }) {
         key={`${layer.layerId}-fill-${index}`}
         source={layer.sourceId}
         source-layer={layer.sourceFileName}
-        beforeId="label_airport"
+        beforeId={beforeId}
         layout={{
           visibility: layer.isLayerOn ? 'visible' : 'none',
         }}
@@ -272,7 +273,7 @@ function WatershedLayers({ layer, index }) {
         key={`${layer.layerId}-lines-${index}`}
         source={layer.sourceId}
         source-layer={layer.sourceFileName}
-        beforeId="label_airport"
+        beforeId={beforeId}
         layout={{
           visibility: layer.isLayerOn ? 'visible' : 'none',
           'line-sort-key': 5,
@@ -329,7 +330,7 @@ function PmTileLayers({ layer, index }) {
 
 // Transparent fill layer so mousemove/mouseleave fire over the full plume area,
 // not just the outline stroke. Line layer preserves the visual yellow outline.
-function PlumeLayers({ layer, index }) {
+function PlumeLayers({ layer, index, beforeId }: { layer; index; beforeId?: string }) {
   return (
     <Source
       id={layer.sourceId}
@@ -344,7 +345,7 @@ function PlumeLayers({ layer, index }) {
         key={`${layer.layerId}-lines-${index}`}
         source={layer.sourceId}
         source-layer={layer.sourceFileName}
-        beforeId="label_airport"
+        beforeId={beforeId}
         layout={{ visibility: layer.isLayerOn ? 'visible' : 'none' }}
         paint={{
           'line-color': [
@@ -367,7 +368,7 @@ function PlumeLayers({ layer, index }) {
         key={`${layer.layerId}-fill-${index}`}
         source={layer.sourceId}
         source-layer={layer.sourceFileName}
-        beforeId="label_airport"
+        beforeId={beforeId}
         layout={{ visibility: layer.isLayerOn ? 'visible' : 'none' }}
         paint={{ 'fill-color': transparent }}
       />
@@ -418,6 +419,7 @@ export default function BaseMap({
   const plumeRestorationRanRef = useRef(false)
 
   const [isMapLoaded, setIsMapLoaded] = useState(false)
+  const [basemapBeforeId, setBasemapBeforeId] = useState<string | undefined>(undefined)
   const [layerErrors, setLayerErrors] = useState<Record<string, string>>({})
   const [isLoadingTiles, setIsLoadingTiles] = useState(false)
   const [showLoadingIndicator, setShowLoadingIndicator] = useState(false)
@@ -782,9 +784,18 @@ export default function BaseMap({
   }, [isMapLoaded, initialDispersalPoint, watershedLayer, plumeLayer])
 
   const handleMapLoad = () => {
+    const map = mapRef.current?.getMap()
+    // Resolve basemapBeforeId BEFORE setIsMapLoaded so the shoreline layer mounts with the
+    // correct anchor on its first render. Shoreline anchors to the lowest label so it sits
+    // beneath every basemap label; overlays anchor to "shoreline-emphasis" so they always
+    // land just below the shoreline.
+    if (map) {
+      const layers = map.getStyle()?.layers ?? []
+      setBasemapBeforeId(resolveBasemapBeforeId(layers))
+    }
+
     setIsMapLoaded(true)
 
-    const map = mapRef.current?.getMap()
     if (!map || !watershedLayer) {
       return
     }
@@ -863,7 +874,7 @@ export default function BaseMap({
         ref={mapRef}
         style={{ width: '100%', height: '100%' }}
         initialViewState={initialViewState}
-        mapStyle={`https://api.maptiler.com/maps/basic/style.json?key=${apiKey}`}
+        mapStyle={`https://api.maptiler.com/maps/hybrid/style.json?key=${apiKey}`}
         onLoad={() => handleMapLoad()}
         onMoveEnd={handleMoveEnd}
         attributionControl={false}
@@ -881,20 +892,39 @@ export default function BaseMap({
         )}
         {/* Layer visual stack (bottom → top):
             base style → COG (lulc/sed_export) → rastertiles (sed_dispersal/reef_extent)
-            → benthic → regions/countries → watershed → plumes → map labels
-            Watershed rendered first so it exists as a beforeId anchor for all layers below it */}
+            → benthic → regions/countries → watershed → plumes → shoreline → map labels
+            Shoreline mounts first so it exists as the beforeId anchor for the overlays below. */}
+        {isMapLoaded && (
+          <Layer
+            id="shoreline-emphasis"
+            type="line"
+            source="maptiler_planet"
+            source-layer="water"
+            beforeId={basemapBeforeId}
+            filter={['==', ['get', 'class'], 'ocean']}
+            paint={{
+              'line-color': '#000',
+              'line-width': ['interpolate', ['linear'], ['zoom'], 0, 0.5, 5, 1, 10, 1.75, 15, 2.5],
+            }}
+          />
+        )}
         {isMapLoaded && watershedLayer && (
           <WatershedLayers
             key={`layer-${watershedIndex}`}
             layer={watershedLayer}
             index={watershedIndex}
+            beforeId="shoreline-emphasis"
           />
         )}
         {/* Plumes rendered outside the main loop so "plumes" and "plumes-lines" are stable
-            layer ID anchors; beforeId="label_airport" places them above watershed but below map labels.
-            JSX order within PlumeLayers: lines first (lower), fill second (higher) */}
+            layer ID anchors. JSX order within PlumeLayers: lines first (lower), fill second (higher) */}
         {isMapLoaded && plumeLayer && (
-          <PlumeLayers key={plumeLayer.sourceId} layer={plumeLayer} index={plumeLayerIndex} />
+          <PlumeLayers
+            key={plumeLayer.sourceId}
+            layer={plumeLayer}
+            index={plumeLayerIndex}
+            beforeId="shoreline-emphasis"
+          />
         )}
         {/* Benthic rendered before the main loop so rastertile layers can reference it via beforeId.
             beforeId="watershed" places it as the lowest app layer, just below regions/countries */}

--- a/src/utils/mapUtils.ts
+++ b/src/utils/mapUtils.ts
@@ -459,3 +459,37 @@ export async function getAllYearZonalStats(lngLat) {
   const results = await Promise.all(zonalStatsPromises)
   return Object.assign({}, ...results)
 }
+
+type LayerWithIdAndType = {
+  id: string
+  type?: string
+}
+
+// Find the first symbol (label) layer that sits above the last opaque/blocking layer.
+// Some basemaps insert symbol layers early in the stack and continue adding fills/hillshade
+// afterwards; anchoring overlays to the *first* symbol would bury them under those later fills.
+export const resolveBasemapBeforeId = (layers: LayerWithIdAndType[]): string | undefined => {
+  const BLOCKING_TYPES = new Set(['fill', 'fill-extrusion', 'hillshade', 'raster'])
+
+  let lastBlockingIndex = -1
+  for (let i = 0; i < layers.length; i++) {
+    if (layers[i].type && BLOCKING_TYPES.has(layers[i].type as string)) {
+      lastBlockingIndex = i
+    }
+  }
+
+  for (let i = lastBlockingIndex + 1; i < layers.length; i++) {
+    if (layers[i].type === 'symbol') {
+      return layers[i].id
+    }
+  }
+
+  // Fallback: first symbol anywhere in the stack
+  const firstSymbol = layers.find((layer) => layer.type === 'symbol')
+  if (firstSymbol) {
+    return firstSymbol.id
+  }
+
+  // Last resort: first non-background layer
+  return layers.find((layer) => layer.type !== 'background')?.id
+}


### PR DESCRIPTION
## Summary

-   Switched the basemap from MapTiler basic to hybrid (satellite imagery).
-   Added a dark shoreline-emphasis outline around oceans, rendered above all overlay layers and beneath all basemap labels.
-   Replaced the hardcoded label_airport/label_road beforeId anchors (which only existed in the basic style) with a single helper in mapUtils, resolveBasemapBeforeId, used to anchor the shoreline just below all basemap labels.
-   Watershed and plume overlays now anchor to the shoreline-emphasis layer itself (beforeId="shoreline-emphasis"), so they always render just below the shoreline regardless of mount or remount order. Final stack (bottom to top): basemap -> watershed -> plumes -> shoreline -> labels.
- 

## Test plan

- [x]   Map loads with satellite imagery, not the old vector basic style.
- [x]   All ocean coastlines have a thin black emphasis line that scales with zoom (subtle at world view, more pronounced at coastal zooms).
- [x]   Shoreline stays above watershed, plume, benthic, and sediment-export overlays at all zoom levels; no flicker or "pop to top" as the map settles after load.
- [x]   Toggle layers on/off, change years, click watersheds and plumes - shoreline remains above all overlays throughout, including after overlays unmount and remount.
- [x]   Place/country/POI labels all render above the shoreline; the shoreline never covers a label.

## Every PR

Before merging, the developer of this pull request has checked the following:

- [x] Changes have been tested locally without errors
- [x] Lint has run and any errors have been resolved
- [x] Prettier has run on any changed files
- [x] Storybook stories have run and any errors have been resolved
- [x] Pre-existing unit tests have run and passed
  - [ ] Unit tests have been added or updated, where possible, to prevent future regressions

## Post-Merge

- [ ] Code has merged and build success is confirmed in 'Actions'
- [ ] The corresponding Trello ticket has moved to the appropriate list (likely User-QA)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated map styling to hybrid mode for improved visual clarity.
  * Added shoreline emphasis layer to enhance coastal feature visibility.

* **Improvements**
  * Enhanced layer stacking system for better overlay organization and positioning.
  * Improved placement of watershed and plume visualization layers for consistent visual hierarchy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->