### PR TITLE
fix: [C152-plume-select] Highlight selected plume boundary on map and track selection state

### DIFF
--- a/src/components/BaseMap/BaseMap.tsx
+++ b/src/components/BaseMap/BaseMap.tsx
@@ -347,7 +347,7 @@ function PlumeLayers({ layer, index }) {
         key={`${layer.layerId}-fill-${index}`}
         source={layer.sourceId}
         source-layer={layer.sourceFileName}
-        beforeId={`${layer.layerId}-lines`}
+        beforeId="label_airport"
         layout={{ visibility: layer.isLayerOn ? 'visible' : 'none' }}
         paint={{ 'fill-color': transparent }}
       />
@@ -860,8 +860,8 @@ export default function BaseMap({
             index={watershedIndex}
           />
         )}
-        {/* Plumes rendered before rastertiles so sed_dispersal can use "plumes" as beforeId,
-            ensuring the ocean raster always sits below the plume outlines on remount */}
+        {/* Plumes rendered outside the main loop so "plumes" and "plumes-lines" are stable
+            layer ID anchors; beforeId="label_airport" places them above watershed but below map labels */}
         {isMapLoaded && plumeLayer && (
           <PlumeLayers key={plumeLayer.sourceId} layer={plumeLayer} index={plumeLayerIndex} />
         )}

--- a/src/components/BaseMap/BaseMap.tsx
+++ b/src/components/BaseMap/BaseMap.tsx
@@ -324,22 +324,12 @@ function PlumeLayers({ layer, index }) {
       url={`pmtiles://${layer.link}`}
     >
       <Layer
-        id={layer.layerId}
-        type="fill"
-        key={`${layer.layerId}-fill-${index}`}
-        source={layer.sourceId}
-        source-layer={layer.sourceFileName}
-        beforeId="watershed"
-        layout={{ visibility: layer.isLayerOn ? 'visible' : 'none' }}
-        paint={{ 'fill-color': transparent }}
-      />
-      <Layer
         id={`${layer.layerId}-lines`}
         type="line"
         key={`${layer.layerId}-lines-${index}`}
         source={layer.sourceId}
         source-layer={layer.sourceFileName}
-        beforeId="watershed"
+        beforeId="label_airport"
         layout={{ visibility: layer.isLayerOn ? 'visible' : 'none' }}
         paint={{
           'line-color': [
@@ -350,6 +340,16 @@ function PlumeLayers({ layer, index }) {
           ],
           'line-width': ['case', ['boolean', ['feature-state', 'select'], false], 3, 1],
         }}
+      />
+      <Layer
+        id={layer.layerId}
+        type="fill"
+        key={`${layer.layerId}-fill-${index}`}
+        source={layer.sourceId}
+        source-layer={layer.sourceFileName}
+        beforeId={`${layer.layerId}-lines`}
+        layout={{ visibility: layer.isLayerOn ? 'visible' : 'none' }}
+        paint={{ 'fill-color': transparent }}
       />
     </Source>
   )
@@ -397,23 +397,25 @@ export default function BaseMap({
   dispersalPointRef.current = dispersalPoint
   const plumeClickRef = useRef<string | number | null>(null)
   const plumeLayerRef = useRef<typeof plumeLayer>(undefined)
+  const plumeRestorationRanRef = useRef(false)
 
   const [isMapLoaded, setIsMapLoaded] = useState(false)
 
   const [layerErrors, setLayerErrors] = useState<Record<string, string>>({})
 
   const mapLayersLoadingError = useMemo(() => Object.keys(layerErrors).length > 0, [layerErrors])
-  const watershedIndex = useMemo(
-    () => mapLayers.findIndex((l) => l.layerId === 'watershed'),
+  const watershedLayer = useMemo(
+    () => mapLayers.find((l) => l.layerId === 'watershed'),
     [mapLayers],
   )
-  const watershedLayer = watershedIndex >= 0 ? mapLayers[watershedIndex] : undefined
-  const plumeLayerIndex = useMemo(() => {
-    const activeIdx = mapLayers.findIndex((l) => l.layerId === 'plumes' && l.isLayerOn)
-    return activeIdx >= 0 ? activeIdx : mapLayers.findIndex((l) => l.layerId === 'plumes')
-  }, [mapLayers])
-
-  const plumeLayer = plumeLayerIndex >= 0 ? mapLayers[plumeLayerIndex] : undefined
+  const watershedIndex = watershedLayer ? mapLayers.indexOf(watershedLayer) : -1
+  const plumeLayer = useMemo(
+    () =>
+      mapLayers.find((l) => l.layerId === 'plumes' && l.isLayerOn) ??
+      mapLayers.find((l) => l.layerId === 'plumes'),
+    [mapLayers],
+  )
+  const plumeLayerIndex = plumeLayer ? mapLayers.indexOf(plumeLayer) : -1
   plumeLayerRef.current = plumeLayer
   const previousPlumeLayer = usePrevious(plumeLayer)
   const benthicSubLayerFillExpression = useMemo(
@@ -620,36 +622,6 @@ export default function BaseMap({
     }
   }, [isMapLoaded])
 
-  useEffect(() => {
-    if (!isMapLoaded) {
-      return
-    }
-
-    const map = mapRef.current?.getMap()
-    if (!map) {
-      return
-    }
-
-    // Keep plume boundary above thematic overlays after layer updates
-    // (e.g. year switches/toggles can reinsert layers and shift stack order).
-    const enforcePlumeLayerOrder = () => {
-      const plumeFillId = 'plumes'
-      const plumeLineId = 'plumes-lines'
-
-      if (!map.getLayer(plumeLineId)) {
-        return
-      }
-
-      if (map.getLayer(plumeFillId)) {
-        map.moveLayer(plumeFillId, plumeLineId)
-      }
-
-      map.moveLayer(plumeLineId)
-    }
-
-    enforcePlumeLayerOrder()
-  }, [isMapLoaded, mapLayers])
-
   // When selectedFeature is cleared externally (e.g., dropdown region change),
   // remove the watershed visual highlight from the map.
   useEffect(() => {
@@ -724,9 +696,17 @@ export default function BaseMap({
 
   // Plume restoration from URL
   useEffect(() => {
-    if (!isMapLoaded || !initialDispersalPoint || !watershedLayer || !plumeLayer) {
+    if (
+      plumeRestorationRanRef.current ||
+      !isMapLoaded ||
+      !initialDispersalPoint ||
+      !watershedLayer ||
+      !plumeLayer
+    ) {
       return undefined
     }
+
+    plumeRestorationRanRef.current = true
 
     const map = mapRef.current?.getMap()
     if (!map) {
@@ -745,6 +725,16 @@ export default function BaseMap({
         if (!feature) {
           onDispersalPointChange(null)
           return
+        }
+
+        // Guard against race condition: skip if the user already clicked a new plume
+        if (plumeClickRef.current == null) {
+          const currentPlumeLayer = plumeLayerRef.current
+          const restoredId = feature.id
+          if (currentPlumeLayer && restoredId != null) {
+            const featureId = isNaN(Number(restoredId)) ? restoredId : Number(restoredId)
+            setPolygonSelect(map, plumeClickRef, currentPlumeLayer, featureId)
+          }
         }
 
         void (async () => {

--- a/src/components/BaseMap/BaseMap.tsx
+++ b/src/components/BaseMap/BaseMap.tsx
@@ -32,6 +32,7 @@ import maplibregl, {
 import * as pmtiles from 'pmtiles'
 import { cogProtocol } from '@geomatico/maplibre-cog-protocol'
 import useResponsive from '../../hooks/useResponsive'
+import { usePrevious } from '../../hooks/usePrevious'
 import LoadingState from '../LoadingState/LoadingState'
 import { RegionOption } from '../../types/RegionDataTypes'
 import {
@@ -80,7 +81,7 @@ interface HandleMapClickParamProps {
   setBreadcrumb: Dispatch<SetStateAction<RegionOption[]>>
   onDispersalPointChange: (point: { lat: number; lng: number } | null) => void
   clearWatershedSelection: () => void
-  setSelectedPlumeWatershedId: Dispatch<SetStateAction<string | null>>
+
   requestIdRef: RefObject<number>
 }
 
@@ -203,18 +204,10 @@ const handleMapClick = async (e: MapMouseEvent, clickParams: HandleMapClickParam
     setBreadcrumb,
     onDispersalPointChange,
     clearWatershedSelection,
-    setSelectedPlumeWatershedId,
     requestIdRef,
   } = clickParams
 
   clearWatershedSelection()
-  const clickedPlumeFeature = (e as MapMouseEvent & { features?: MapGeoJSONFeature[] })
-    .features?.[0]
-  const clickedPlumeWatershedId = clickedPlumeFeature?.properties?.watershed_id
-
-  setSelectedPlumeWatershedId(
-    clickedPlumeWatershedId != null ? String(clickedPlumeWatershedId) : null,
-  )
   onDispersalPointChange({ lng: e.lngLat.lng, lat: e.lngLat.lat })
 
   const requestId = ++requestIdRef.current
@@ -403,9 +396,10 @@ export default function BaseMap({
   const dispersalPointRef = useRef(dispersalPoint)
   dispersalPointRef.current = dispersalPoint
   const plumeClickRef = useRef<string | number | null>(null)
+  const plumeLayerRef = useRef<typeof plumeLayer>(undefined)
 
   const [isMapLoaded, setIsMapLoaded] = useState(false)
-  const [, setSelectedPlumeWatershedId] = useState<string | null>(null)
+
   const [layerErrors, setLayerErrors] = useState<Record<string, string>>({})
 
   const mapLayersLoadingError = useMemo(() => Object.keys(layerErrors).length > 0, [layerErrors])
@@ -420,6 +414,8 @@ export default function BaseMap({
   }, [mapLayers])
 
   const plumeLayer = plumeLayerIndex >= 0 ? mapLayers[plumeLayerIndex] : undefined
+  plumeLayerRef.current = plumeLayer
+  const previousPlumeLayer = usePrevious(plumeLayer)
   const benthicSubLayerFillExpression = useMemo(
     () => [
       'case',
@@ -448,7 +444,6 @@ export default function BaseMap({
       clearPolygonSelect(map, plumeClickRef, plumeLayer)
     }
 
-    setSelectedPlumeWatershedId(null)
     clearTopPolygonsFill('watershed')
     clearSelectedPlumeWatershedStats()
     onDispersalPointChange(null)
@@ -590,12 +585,17 @@ export default function BaseMap({
       return
     }
 
+    // Clear the highlighted polygon from the previous plume layer before reselecting on the new one
+    if (previousPlumeLayer && previousPlumeLayer.sourceId !== plumeLayer.sourceId) {
+      clearPolygonSelect(map, plumeClickRef, previousPlumeLayer)
+    }
+
     const plumeFeatureId = isNaN(Number(selectedPlumeId))
       ? selectedPlumeId
       : Number(selectedPlumeId)
 
     setPolygonSelect(map, plumeClickRef, plumeLayer, plumeFeatureId)
-  }, [isMapLoaded, plumeLayer, mapLayers])
+  }, [isMapLoaded, plumeLayer, mapLayers, previousPlumeLayer])
 
   useEffect(() => {
     if (!isMapLoaded) {
@@ -673,7 +673,6 @@ export default function BaseMap({
     }
 
     clearPolygonSelect(map, plumeClickRef, plumeLayer)
-    setSelectedPlumeWatershedId(null)
   }, [dispersalPoint, isMapLoaded, plumeLayer])
 
   // Watershed restoration from URL
@@ -795,19 +794,16 @@ export default function BaseMap({
 
     const onPlumeClick = (e: MapLayerMouseEvent) => {
       const clickedPlumeFeature = e.features?.[0]
-      console.log('clickedPlumeFeature ', clickedPlumeFeature)
       const clickedPlumeWatershedId = clickedPlumeFeature?.properties?.watershed_id
+      const currentPlumeLayer = plumeLayerRef.current
 
-      if (plumeLayer && clickedPlumeWatershedId != null) {
+      if (currentPlumeLayer && clickedPlumeWatershedId != null) {
         const currentFeatureId = isNaN(Number(clickedPlumeWatershedId))
           ? clickedPlumeWatershedId
           : Number(clickedPlumeWatershedId)
-        console.log('plumeLayer ', plumeLayer)
-        console.log('onPlumeClick currentFeatureId ', currentFeatureId)
-        console.log('onPlumeClick plumeClickRef ', plumeClickRef)
 
-        clearPolygonSelect(map, plumeClickRef, plumeLayer)
-        setPolygonSelect(map, plumeClickRef, plumeLayer, currentFeatureId)
+        clearPolygonSelect(map, plumeClickRef, currentPlumeLayer)
+        setPolygonSelect(map, plumeClickRef, currentPlumeLayer, currentFeatureId)
       }
 
       handleMapClick(e, {
@@ -817,7 +813,6 @@ export default function BaseMap({
         setBreadcrumb,
         onDispersalPointChange,
         clearWatershedSelection,
-        setSelectedPlumeWatershedId,
         requestIdRef: plumeRequestIdRef,
       })
     }

--- a/src/components/BaseMap/BaseMap.tsx
+++ b/src/components/BaseMap/BaseMap.tsx
@@ -27,6 +27,7 @@ import maplibregl, {
   MapGeoJSONFeature,
   LngLat,
   MapMouseEvent,
+  MapLayerMouseEvent,
 } from 'maplibre-gl'
 import * as pmtiles from 'pmtiles'
 import { cogProtocol } from '@geomatico/maplibre-cog-protocol'
@@ -320,12 +321,13 @@ function PmTileLayers({ layer, index }) {
 
 // Transparent fill layer so mousemove/mouseleave fire over the full plume area,
 // not just the outline stroke. Line layer preserves the visual yellow outline.
-function PlumeLayers({ layer, index, selectedPlumeWatershedId }) {
+function PlumeLayers({ layer, index }) {
   return (
     <Source
       id={layer.sourceId}
       key={`${layer.sourceId}-source`}
       type="vector"
+      promoteId="watershed_id"
       url={`pmtiles://${layer.link}`}
     >
       <Layer
@@ -349,17 +351,11 @@ function PlumeLayers({ layer, index, selectedPlumeWatershedId }) {
         paint={{
           'line-color': [
             'case',
-            ['==', ['to-string', ['get', 'watershed_id']], selectedPlumeWatershedId ?? ''],
+            ['boolean', ['feature-state', 'select'], false],
             plumeOutlineSelectedColor,
             layer.outlineColor,
           ],
-          'line-width': [
-            'case',
-            ['==', ['to-string', ['get', 'watershed_id']], selectedPlumeWatershedId ?? ''],
-            3,
-            1,
-          ],
-          'line-dasharray': layer.outlineStyle ? [0, 2, 5] : [2, 0],
+          'line-width': ['case', ['boolean', ['feature-state', 'select'], false], 3, 1],
         }}
       />
     </Source>
@@ -402,13 +398,14 @@ export default function BaseMap({
   const plumeRequestIdRef = useRef(0) // Tracks the latest plume click fetch so earlier, slower responses don't overwrite newer ones.
   // Latest-ref pattern: written every render so MapLibre closures registered once (e.g. onPlumeClick)
   // always read the current value without needing to re-register the listener.
-  const selectedYearRef = useRef(selectedYear)
+  const selectedYearRef = useRef<number>(selectedYear)
   selectedYearRef.current = selectedYear
   const dispersalPointRef = useRef(dispersalPoint)
   dispersalPointRef.current = dispersalPoint
+  const plumeClickRef = useRef<string | number | null>(null)
 
   const [isMapLoaded, setIsMapLoaded] = useState(false)
-  const [selectedPlumeWatershedId, setSelectedPlumeWatershedId] = useState<string | null>(null)
+  const [, setSelectedPlumeWatershedId] = useState<string | null>(null)
   const [layerErrors, setLayerErrors] = useState<Record<string, string>>({})
 
   const mapLayersLoadingError = useMemo(() => Object.keys(layerErrors).length > 0, [layerErrors])
@@ -445,11 +442,17 @@ export default function BaseMap({
 
   const clearPlumeSelection = useCallback(() => {
     plumeRequestIdRef.current += 1 // Prevent a stale plume response from applying if the fetch resolves after this selection is cleared.
+
+    const map = mapRef.current?.getMap()
+    if (map && plumeLayer) {
+      clearPolygonSelect(map, plumeClickRef, plumeLayer)
+    }
+
     setSelectedPlumeWatershedId(null)
     clearTopPolygonsFill('watershed')
     clearSelectedPlumeWatershedStats()
     onDispersalPointChange(null)
-  }, [clearTopPolygonsFill, clearSelectedPlumeWatershedStats, onDispersalPointChange])
+  }, [clearTopPolygonsFill, clearSelectedPlumeWatershedStats, onDispersalPointChange, plumeLayer])
 
   const clearWatershedSelection = useCallback(() => {
     clearSelectedFeature()
@@ -545,7 +548,7 @@ export default function BaseMap({
     }
   }, [])
 
-  // Re-apply plume watershed highlights when the year changes while a plume is active.
+  // Re-apply plume watershed stats when the year changes while a plume is active.
   // dispersalPoint and selectedPlumeWatershedStats are intentionally read via refs/store
   // so this effect only fires on year changes, not on every plume click.
   useEffect(() => {
@@ -574,6 +577,25 @@ export default function BaseMap({
       setBreadcrumb,
     })
   }, [selectedYear, isMapLoaded, watershedLayer, setBreadcrumb])
+
+  // Re-apply plume outline selection when plume layer/source is (re)available.
+  useEffect(() => {
+    if (!isMapLoaded || !plumeLayer) {
+      return
+    }
+
+    const map = mapRef.current?.getMap()
+    const selectedPlumeId = plumeClickRef.current
+    if (!map || selectedPlumeId == null) {
+      return
+    }
+
+    const plumeFeatureId = isNaN(Number(selectedPlumeId))
+      ? selectedPlumeId
+      : Number(selectedPlumeId)
+
+    setPolygonSelect(map, plumeClickRef, plumeLayer, plumeFeatureId)
+  }, [isMapLoaded, plumeLayer, mapLayers])
 
   useEffect(() => {
     if (!isMapLoaded) {
@@ -629,7 +651,7 @@ export default function BaseMap({
   }, [isMapLoaded, mapLayers])
 
   // When selectedFeature is cleared externally (e.g., dropdown region change),
-  // remove the visual highlight from the map.
+  // remove the watershed visual highlight from the map.
   useEffect(() => {
     if (!selectedFeature && polygonClickRef.current && isMapLoaded) {
       const map = mapRef.current?.getMap()
@@ -638,6 +660,21 @@ export default function BaseMap({
       }
     }
   }, [selectedFeature, isMapLoaded, watershedLayer])
+
+  // Clear plume outline selection when plume context is cleared (e.g., region change).
+  useEffect(() => {
+    if (!isMapLoaded || dispersalPoint) {
+      return
+    }
+
+    const map = mapRef.current?.getMap()
+    if (!map || !plumeLayer || !plumeClickRef.current) {
+      return
+    }
+
+    clearPolygonSelect(map, plumeClickRef, plumeLayer)
+    setSelectedPlumeWatershedId(null)
+  }, [dispersalPoint, isMapLoaded, plumeLayer])
 
   // Watershed restoration from URL
   useEffect(() => {
@@ -749,14 +786,30 @@ export default function BaseMap({
       polygonClickBoundRef.current = null
     }
 
-    const onWatershedHover = (e) => {
+    const onWatershedHover = (e: MapLayerMouseEvent) => {
       polygonHoverHandler(map, e, watershedLayer)
     }
-    const onWatershedClick = (e) => {
+    const onWatershedClick = (e: MapLayerMouseEvent) => {
       polygonClickHandler(map, e, watershedLayer)
     }
 
-    const onPlumeClick = (e) =>
+    const onPlumeClick = (e: MapLayerMouseEvent) => {
+      const clickedPlumeFeature = e.features?.[0]
+      console.log('clickedPlumeFeature ', clickedPlumeFeature)
+      const clickedPlumeWatershedId = clickedPlumeFeature?.properties?.watershed_id
+
+      if (plumeLayer && clickedPlumeWatershedId != null) {
+        const currentFeatureId = isNaN(Number(clickedPlumeWatershedId))
+          ? clickedPlumeWatershedId
+          : Number(clickedPlumeWatershedId)
+        console.log('plumeLayer ', plumeLayer)
+        console.log('onPlumeClick currentFeatureId ', currentFeatureId)
+        console.log('onPlumeClick plumeClickRef ', plumeClickRef)
+
+        clearPolygonSelect(map, plumeClickRef, plumeLayer)
+        setPolygonSelect(map, plumeClickRef, plumeLayer, currentFeatureId)
+      }
+
       handleMapClick(e, {
         map,
         watershedLayer,
@@ -767,6 +820,7 @@ export default function BaseMap({
         setSelectedPlumeWatershedId,
         requestIdRef: plumeRequestIdRef,
       })
+    }
 
     polygonHoverBoundRef.current = onWatershedHover
     polygonClickBoundRef.current = onWatershedClick
@@ -824,12 +878,7 @@ export default function BaseMap({
         {/* Plumes rendered before rastertiles so sed_dispersal can use "plumes" as beforeId,
             ensuring the ocean raster always sits below the plume outlines on remount */}
         {isMapLoaded && plumeLayer && (
-          <PlumeLayers
-            key={plumeLayer.sourceId}
-            layer={plumeLayer}
-            index={plumeLayerIndex}
-            selectedPlumeWatershedId={selectedPlumeWatershedId}
-          />
+          <PlumeLayers key={plumeLayer.sourceId} layer={plumeLayer} index={plumeLayerIndex} />
         )}
         {mapLayers.map((layer: LayerInfo, index) => {
           if (layer.layerId === 'watershed') {

--- a/src/components/BaseMap/BaseMap.tsx
+++ b/src/components/BaseMap/BaseMap.tsx
@@ -52,6 +52,7 @@ import { useTranslation } from 'react-i18next'
 import {
   mapFitBoundsDesktopConfig,
   mapFitBoundsMobileConfig,
+  polygonHighlightWidth,
   polygonOutlineHoverColor,
   polygonOutlineSelectColor,
 } from '../../constants'
@@ -63,7 +64,6 @@ import { defaultGlobalRegionOption, regionOptions } from '../../data/regionData'
 import crosshairCursorUrl from '../../assets/crosshair-cursor.svg?url'
 
 const plumeCrosshairCursor = `url("${crosshairCursorUrl}") 10 10, crosshair`
-const plumeOutlineSelectedColor = '#005BFF'
 
 interface ApplyPlumeStatsParams {
   map: maplibregl.Map
@@ -266,9 +266,9 @@ function WatershedLayers({ layer, index }) {
           'line-width': [
             'case',
             ['boolean', ['feature-state', 'hover'], false],
-            4,
+            polygonHighlightWidth,
             ['boolean', ['feature-state', 'select'], false],
-            4,
+            polygonHighlightWidth,
             1,
           ],
           'line-color': [
@@ -335,10 +335,15 @@ function PlumeLayers({ layer, index }) {
           'line-color': [
             'case',
             ['boolean', ['feature-state', 'select'], false],
-            plumeOutlineSelectedColor,
+            polygonOutlineSelectColor,
             layer.outlineColor,
           ],
-          'line-width': ['case', ['boolean', ['feature-state', 'select'], false], 3, 1],
+          'line-width': [
+            'case',
+            ['boolean', ['feature-state', 'select'], false],
+            polygonHighlightWidth,
+            1,
+          ],
         }}
       />
       <Layer

--- a/src/components/BaseMap/BaseMap.tsx
+++ b/src/components/BaseMap/BaseMap.tsx
@@ -61,6 +61,7 @@ import { defaultGlobalRegionOption, regionOptions } from '../../data/regionData'
 import crosshairCursorUrl from '../../assets/crosshair-cursor.svg?url'
 
 const plumeCrosshairCursor = `url("${crosshairCursorUrl}") 10 10, crosshair`
+const plumeOutlineSelectedColor = '#005BFF'
 
 interface ApplyPlumeStatsParams {
   map: maplibregl.Map
@@ -78,6 +79,7 @@ interface HandleMapClickParamProps {
   setBreadcrumb: Dispatch<SetStateAction<RegionOption[]>>
   onDispersalPointChange: (point: { lat: number; lng: number } | null) => void
   clearWatershedSelection: () => void
+  setSelectedPlumeWatershedId: Dispatch<SetStateAction<string | null>>
   requestIdRef: RefObject<number>
 }
 
@@ -200,10 +202,18 @@ const handleMapClick = async (e: MapMouseEvent, clickParams: HandleMapClickParam
     setBreadcrumb,
     onDispersalPointChange,
     clearWatershedSelection,
+    setSelectedPlumeWatershedId,
     requestIdRef,
   } = clickParams
 
   clearWatershedSelection()
+  const clickedPlumeFeature = (e as MapMouseEvent & { features?: MapGeoJSONFeature[] })
+    .features?.[0]
+  const clickedPlumeWatershedId = clickedPlumeFeature?.properties?.watershed_id
+
+  setSelectedPlumeWatershedId(
+    clickedPlumeWatershedId != null ? String(clickedPlumeWatershedId) : null,
+  )
   onDispersalPointChange({ lng: e.lngLat.lng, lat: e.lngLat.lat })
 
   const requestId = ++requestIdRef.current
@@ -310,7 +320,7 @@ function PmTileLayers({ layer, index }) {
 
 // Transparent fill layer so mousemove/mouseleave fire over the full plume area,
 // not just the outline stroke. Line layer preserves the visual yellow outline.
-function PlumeLayers({ layer, index }) {
+function PlumeLayers({ layer, index, selectedPlumeWatershedId }) {
   return (
     <Source
       id={layer.sourceId}
@@ -337,7 +347,18 @@ function PlumeLayers({ layer, index }) {
         beforeId="watershed"
         layout={{ visibility: layer.isLayerOn ? 'visible' : 'none' }}
         paint={{
-          'line-color': layer.outlineColor,
+          'line-color': [
+            'case',
+            ['==', ['to-string', ['get', 'watershed_id']], selectedPlumeWatershedId ?? ''],
+            plumeOutlineSelectedColor,
+            layer.outlineColor,
+          ],
+          'line-width': [
+            'case',
+            ['==', ['to-string', ['get', 'watershed_id']], selectedPlumeWatershedId ?? ''],
+            3,
+            1,
+          ],
           'line-dasharray': layer.outlineStyle ? [0, 2, 5] : [2, 0],
         }}
       />
@@ -387,6 +408,7 @@ export default function BaseMap({
   dispersalPointRef.current = dispersalPoint
 
   const [isMapLoaded, setIsMapLoaded] = useState(false)
+  const [selectedPlumeWatershedId, setSelectedPlumeWatershedId] = useState<string | null>(null)
   const [layerErrors, setLayerErrors] = useState<Record<string, string>>({})
 
   const mapLayersLoadingError = useMemo(() => Object.keys(layerErrors).length > 0, [layerErrors])
@@ -423,6 +445,7 @@ export default function BaseMap({
 
   const clearPlumeSelection = useCallback(() => {
     plumeRequestIdRef.current += 1 // Prevent a stale plume response from applying if the fetch resolves after this selection is cleared.
+    setSelectedPlumeWatershedId(null)
     clearTopPolygonsFill('watershed')
     clearSelectedPlumeWatershedStats()
     onDispersalPointChange(null)
@@ -575,6 +598,36 @@ export default function BaseMap({
     }
   }, [isMapLoaded])
 
+  useEffect(() => {
+    if (!isMapLoaded) {
+      return
+    }
+
+    const map = mapRef.current?.getMap()
+    if (!map) {
+      return
+    }
+
+    // Keep plume boundary above thematic overlays after layer updates
+    // (e.g. year switches/toggles can reinsert layers and shift stack order).
+    const enforcePlumeLayerOrder = () => {
+      const plumeFillId = 'plumes'
+      const plumeLineId = 'plumes-lines'
+
+      if (!map.getLayer(plumeLineId)) {
+        return
+      }
+
+      if (map.getLayer(plumeFillId)) {
+        map.moveLayer(plumeFillId, plumeLineId)
+      }
+
+      map.moveLayer(plumeLineId)
+    }
+
+    enforcePlumeLayerOrder()
+  }, [isMapLoaded, mapLayers])
+
   // When selectedFeature is cleared externally (e.g., dropdown region change),
   // remove the visual highlight from the map.
   useEffect(() => {
@@ -711,6 +764,7 @@ export default function BaseMap({
         setBreadcrumb,
         onDispersalPointChange,
         clearWatershedSelection,
+        setSelectedPlumeWatershedId,
         requestIdRef: plumeRequestIdRef,
       })
 
@@ -770,7 +824,12 @@ export default function BaseMap({
         {/* Plumes rendered before rastertiles so sed_dispersal can use "plumes" as beforeId,
             ensuring the ocean raster always sits below the plume outlines on remount */}
         {isMapLoaded && plumeLayer && (
-          <PlumeLayers key={plumeLayer.sourceId} layer={plumeLayer} index={plumeLayerIndex} />
+          <PlumeLayers
+            key={plumeLayer.sourceId}
+            layer={plumeLayer}
+            index={plumeLayerIndex}
+            selectedPlumeWatershedId={selectedPlumeWatershedId}
+          />
         )}
         {mapLayers.map((layer: LayerInfo, index) => {
           if (layer.layerId === 'watershed') {
@@ -826,7 +885,7 @@ export default function BaseMap({
                     type="raster"
                     key={`${layer.layerId}-${index}`}
                     source={layer.sourceId}
-                    beforeId="plumes"
+                    beforeId="benthic"
                   />
                 </Source>
               )

--- a/src/components/BaseMap/BaseMap.tsx
+++ b/src/components/BaseMap/BaseMap.tsx
@@ -45,6 +45,7 @@ import {
   querySourceFeatureAtPointWhenReady,
   setPolygonSelect,
   getAllYearZonalStats,
+  buildBenthicFillExpression,
 } from '../../utils/mapUtils'
 import { SourceDataEvent } from '../../types/MapLayerErrorTypes'
 import { Snackbar } from '@mui/material'
@@ -424,22 +425,7 @@ export default function BaseMap({
   plumeLayerRef.current = plumeLayer
   const previousPlumeLayer = usePrevious(plumeLayer)
   const benthicSubLayerFillExpression = useMemo(
-    () => [
-      'case',
-      ['==', ['get', 'class_name'], 'Coral/Algae'],
-      benthicFillColors['coral_algae'],
-      ['==', ['get', 'class_name'], 'Benthic Microalgae'],
-      benthicFillColors['microalgal_mats'],
-      ['==', ['get', 'class_name'], 'Rock'],
-      benthicFillColors['rock'],
-      ['==', ['get', 'class_name'], 'Rubble'],
-      benthicFillColors['rubble'],
-      ['==', ['get', 'class_name'], 'Sand'],
-      benthicFillColors['sand'],
-      ['==', ['get', 'class_name'], 'Seagrass'],
-      benthicFillColors['seagrass'],
-      transparent, // Default / other
-    ],
+    () => buildBenthicFillExpression(benthicFillColors),
     [benthicFillColors],
   )
 

--- a/src/components/MapContainer/MapContainer.tsx
+++ b/src/components/MapContainer/MapContainer.tsx
@@ -44,7 +44,7 @@ export default function MapContainer() {
   const shouldSyncRegionParam = regionParam !== normalizedRegionParam
 
   const layersParam = searchParams.get('layers')
-  const selectedLayers = getValidLayers(layersParam)
+  const selectedLayers = useMemo(() => getValidLayers(layersParam), [layersParam])
   const normalizedLayersParam = selectedLayers.length > 0 ? selectedLayers.join(',') : 'none'
   const shouldSyncLayersParam = layersParam !== normalizedLayersParam
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -94,4 +94,5 @@ export const mapFitBoundsMobileConfig = {
 export const plumeOutlineColor = '#FFEA46'
 export const polygonOutlineHoverColor = '#00FF01'
 export const polygonOutlineSelectColor = '#0000FF'
+export const polygonHighlightWidth = 3
 export const topContributingWatershedColorFills = ['#FFA600', '#D86D83', '#7A5195']

--- a/src/hooks/usePrevious.ts
+++ b/src/hooks/usePrevious.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from 'react'
 
 export function usePrevious<T>(value: T): T | undefined {
-  const ref = useRef<T>(undefined)
+  const ref = useRef<T | undefined>(undefined)
 
   useEffect(() => {
     ref.current = value

--- a/src/hooks/usePrevious.ts
+++ b/src/hooks/usePrevious.ts
@@ -1,0 +1,11 @@
+import { useEffect, useRef } from 'react'
+
+export function usePrevious<T>(value: T): T | undefined {
+  const ref = useRef<T>(undefined)
+
+  useEffect(() => {
+    ref.current = value
+  })
+
+  return ref.current
+}

--- a/src/utils/mapUtils.ts
+++ b/src/utils/mapUtils.ts
@@ -319,6 +319,28 @@ export function querySourceFeatureAtPointWhenReady(
 }
 
 /**
+ * Builds a MapLibre `case` expression that maps benthic class_name values to fill colours.
+ */
+export function buildBenthicFillExpression(colors: Record<string, string>): unknown[] {
+  return [
+    'case',
+    ['==', ['get', 'class_name'], 'Coral/Algae'],
+    colors['coral_algae'],
+    ['==', ['get', 'class_name'], 'Benthic Microalgae'],
+    colors['microalgal_mats'],
+    ['==', ['get', 'class_name'], 'Rock'],
+    colors['rock'],
+    ['==', ['get', 'class_name'], 'Rubble'],
+    colors['rubble'],
+    ['==', ['get', 'class_name'], 'Sand'],
+    colors['sand'],
+    ['==', ['get', 'class_name'], 'Seagrass'],
+    colors['seagrass'],
+    transparent,
+  ]
+}
+
+/**
  * Builds a MapLibre `match` expression that assigns a colour to each watershed ID.
  * Falls back to `fallback` for any ID not in the list, or when `ids` is empty.
  */

--- a/src/utils/mapUtils.ts
+++ b/src/utils/mapUtils.ts
@@ -8,6 +8,7 @@ import {
   Map,
   MapGeoJSONFeature,
   MapLayerMouseEvent,
+  MapSourceDataEvent,
 } from 'maplibre-gl'
 import { RefObject } from 'react'
 import { LayerInfo, SubLayerInfo } from '../types/MapDataTypes'
@@ -297,11 +298,12 @@ export function querySourceFeatureAtPointWhenReady(
     }
     settled = true
     map.off('sourcedata', onSourceData)
+    map.off('sourcedataabort', onSourceDataAbort)
     clearTimeout(timeoutId)
     onResult(result)
   }
 
-  const onSourceData = (e: { sourceId?: string; isSourceLoaded?: boolean }) => {
+  const onSourceData = (e: MapSourceDataEvent) => {
     if (settled || e.sourceId !== sourceId) {
       return
     }
@@ -311,7 +313,16 @@ export function querySourceFeatureAtPointWhenReady(
       settle(feature)
     }
   }
+
+  // Fired when tile requests for this source are aborted (e.g. network drop, source removed).
+  const onSourceDataAbort = (e: MapSourceDataEvent) => {
+    if (e.sourceId === sourceId) {
+      settle(null)
+    }
+  }
+
   map.on('sourcedata', onSourceData)
+  map.on('sourcedataabort', onSourceDataAbort)
 
   const timeoutId = setTimeout(() => settle(null), timeoutMs)
 


### PR DESCRIPTION
- **Plume selection UX**: Clicking a plume now selects it and highlights its boundary using a distinct outline color and increased line width.

- **Selection state handling**: Selection is tracked via MapLibre ‎`feature-state` instead of React state, with helpers to apply and clear selection, and logic to re-apply selection when plume layers reload or switch.

- **Interaction typing**: Map click handlers are updated to use ‎`MapLayerMouseEvent` so ‎`features` typing is accurate without casts.

- **Layer ordering:** Plume fill and outline layers are reordered and rendered outside the main loop so the ‎`plumes` and ‎`plumes-lines` layers sit above other thematic overlays but still below watershed and basemap labels.

- **Raster tile anchoring**: Raster tiles now anchor with ‎`beforeId="benthic"` instead of ‎`plumes`, and comments are updated to reflect the new stacking model.

- **Styling constants**: Plume selection outline color and line width are refactored into shared constants (aligned with watershed selection styling) for consistent selection visuals.

- **Map utils**: Benthic fill expressions are factored into a reusable helper in ‎`mapUtils`, and ‎`querySourceFeatureAtPointWhenReady` is updated to handle ‎`sourcedataabort` events safely.

- **Cleanup and safety**: Unused plume selection props/state are removed, ‎`usePrevious` is introduced to track the prior plume layer for proper cleanup, and console logs / stale comments are cleaned up, and ‎`onSourceDataAbort` is introduced to ‎`querySourceFeatureAtPointWhenReady` to ensure the marker plume is cleared when tile requests are aborted or layers are removed or not loading.

## Every PR

Before merging, the developer of this pull request has checked the following:

- [x] Changes have been tested locally without errors
- [x] Lint has run and any errors have been resolved
- [x] Prettier has run on any changed files
- [x] Storybook stories have run and any errors have been resolved
- [x] Pre-existing unit tests have run and passed
  - [ ] Unit tests have been added or updated, where possible, to prevent future regressions

## Post-Merge

- [ ] Code has merged and build success is confirmed in 'Actions'
- [ ] The corresponding Trello ticket has moved to the appropriate list (likely User-QA)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Clickable plume selection with immediate visual highlighting and easy clear/reset.
  * New prior-value hook enables smoother UI state behavior.

* **Improvements**
  * More accurate benthic coloring for map areas.
  * Improved map layer ordering for better raster and label presentation.
  * Reduced duplicate restoration of plume selection and more reliable selection behavior on map updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->