### PR TITLE
fix: [C181]: Always render raster tile by toggling visibility instead of mounting

### DIFF
--- a/src/components/BaseMap/BaseMap.tsx
+++ b/src/components/BaseMap/BaseMap.tsx
@@ -423,6 +423,7 @@ export default function BaseMap({
   )
   const plumeLayerIndex = plumeLayer ? mapLayers.indexOf(plumeLayer) : -1
   plumeLayerRef.current = plumeLayer
+  const benthicLayer = useMemo(() => mapLayers.find((l) => l.layerId === 'benthic'), [mapLayers])
   const previousPlumeLayer = usePrevious(plumeLayer)
   const benthicSubLayerFillExpression = useMemo(
     () => buildBenthicFillExpression(benthicFillColors),
@@ -843,7 +844,10 @@ export default function BaseMap({
             <div className={styles['plume-marker']} />
           </Marker>
         )}
-        {/* Watershed always rendered first so other layers can reference it via beforeId */}
+        {/* Layer visual stack (bottom → top):
+            base style → COG (lulc/sed_export) → rastertiles (sed_dispersal/reef_extent)
+            → benthic → regions/countries → watershed → plumes → map labels
+            Watershed rendered first so it exists as a beforeId anchor for all layers below it */}
         {isMapLoaded && watershedLayer && (
           <WatershedLayers
             key={`layer-${watershedIndex}`}
@@ -852,15 +856,43 @@ export default function BaseMap({
           />
         )}
         {/* Plumes rendered outside the main loop so "plumes" and "plumes-lines" are stable
-            layer ID anchors; beforeId="label_airport" places them above watershed but below map labels */}
+            layer ID anchors; beforeId="label_airport" places them above watershed but below map labels.
+            JSX order within PlumeLayers: lines first (lower), fill second (higher) */}
         {isMapLoaded && plumeLayer && (
           <PlumeLayers key={plumeLayer.sourceId} layer={plumeLayer} index={plumeLayerIndex} />
+        )}
+        {/* Benthic rendered before the main loop so rastertile layers can reference it via beforeId.
+            beforeId="watershed" places it as the lowest app layer, just below regions/countries */}
+        {isMapLoaded && benthicLayer && (
+          <Source
+            id={benthicLayer.sourceId}
+            key={`${benthicLayer.sourceId}-source`}
+            type="vector"
+            tiles={[benthicLayer.link]}
+            maxzoom={22}
+            minzoom={0}
+          >
+            <Layer
+              id={benthicLayer.layerId}
+              type="fill"
+              source={benthicLayer.sourceId}
+              source-layer={benthicLayer.sourceFileName}
+              beforeId="watershed"
+              layout={{ visibility: benthicLayer.isLayerOn ? 'visible' : 'none' }}
+              paint={{
+                // @ts-expect-error - doesn't like fill-color being a string?
+                'fill-color': benthicSubLayerFillExpression,
+              }}
+            />
+          </Source>
         )}
         {mapLayers.map((layer: LayerInfo, index) => {
           if (layer.layerId === 'watershed') {
             return null // rendered above, always present
           } else if (layer.layerId === 'plumes') {
             return null // rendered above, always present
+          } else if (layer.layerId === 'benthic') {
+            return null // rendered above the loop so it exists as a beforeId anchor for rastertiles
           } else if (layer.dataType === 'pmtiles') {
             return (
               isMapLoaded && <PmTileLayers key={`layer-${index}`} layer={layer} index={index} />
@@ -895,8 +927,8 @@ export default function BaseMap({
               )
             )
           } else if (layer.dataType === 'rastertiles') {
-            // Always render all rastertiles so tiles stay cached; toggle visibility instead of
-            // mounting/unmounting on year change (avoids re-fetching tiles for sed_dispersal etc.)
+            // Rastertiles sit just below benthic (beforeId="benthic"). All years are always mounted
+            // so tiles stay cached; visibility is toggled instead of mounting/unmounting on year change.
             return (
               isMapLoaded && (
                 <Source
@@ -920,7 +952,7 @@ export default function BaseMap({
               )
             )
           } else {
-            //other should just be 'vectortiles'
+            // Fallback for any non-benthic vectortile layers; beforeId="watershed" places them below watershed
             return (
               isMapLoaded && (
                 <Source
@@ -940,8 +972,7 @@ export default function BaseMap({
                     beforeId="watershed"
                     layout={{ visibility: layer.isLayerOn ? 'visible' : 'none' }}
                     paint={{
-                      // @ts-expect-error - doesn't like fill-color being a string?
-                      'fill-color': benthicSubLayerFillExpression,
+                      'fill-color': transparent,
                     }}
                   />
                 </Source>

--- a/src/components/BaseMap/BaseMap.tsx
+++ b/src/components/BaseMap/BaseMap.tsx
@@ -870,9 +870,7 @@ export default function BaseMap({
               layer.layerId !== 'sed_export' || sedExportSubLayerValue === 'pixel'
 
             return (
-              isMapLoaded &&
-              layer.isLayerOn &&
-              shouldRenderSedExportRaster && (
+              isMapLoaded && (
                 <Source
                   id={layer.sourceId}
                   key={`${layer.sourceId}-${index}`}
@@ -883,19 +881,24 @@ export default function BaseMap({
                   minzoom={6}
                 >
                   <Layer
-                    id={layer.layerId}
+                    id={layer.sourceId}
                     type="raster"
-                    key={`${layer.layerId}-${index}`}
+                    key={`${layer.sourceId}-${index}`}
                     source={layer.sourceId}
-                    beforeId="sed_dispersal"
+                    beforeId="sediment_exposure_2000"
+                    layout={{
+                      visibility:
+                        layer.isLayerOn && shouldRenderSedExportRaster ? 'visible' : 'none',
+                    }}
                   />
                 </Source>
               )
             )
           } else if (layer.dataType === 'rastertiles') {
+            // Always render all rastertiles so tiles stay cached; toggle visibility instead of
+            // mounting/unmounting on year change (avoids re-fetching tiles for sed_dispersal etc.)
             return (
-              isMapLoaded &&
-              layer.isLayerOn && (
+              isMapLoaded && (
                 <Source
                   id={layer.sourceId}
                   key={`${layer.sourceId}-${index}`}
@@ -906,11 +909,12 @@ export default function BaseMap({
                   minzoom={6}
                 >
                   <Layer
-                    id={layer.layerId}
+                    id={layer.sourceId}
                     type="raster"
-                    key={`${layer.layerId}-${index}`}
+                    key={`${layer.sourceId}-${index}`}
                     source={layer.sourceId}
                     beforeId="benthic"
+                    layout={{ visibility: layer.isLayerOn ? 'visible' : 'none' }}
                   />
                 </Source>
               )

--- a/src/components/BaseMap/BaseMap.tsx
+++ b/src/components/BaseMap/BaseMap.tsx
@@ -870,7 +870,9 @@ export default function BaseMap({
               layer.layerId !== 'sed_export' || sedExportSubLayerValue === 'pixel'
 
             return (
-              isMapLoaded && (
+              isMapLoaded &&
+              layer.isLayerOn &&
+              shouldRenderSedExportRaster && (
                 <Source
                   id={layer.sourceId}
                   key={`${layer.sourceId}-${index}`}
@@ -881,15 +883,11 @@ export default function BaseMap({
                   minzoom={6}
                 >
                   <Layer
-                    id={layer.sourceId}
+                    id={layer.layerId}
                     type="raster"
-                    key={`${layer.sourceId}-${index}`}
+                    key={`${layer.layerId}-${index}`}
                     source={layer.sourceId}
                     beforeId="sediment_exposure_2000"
-                    layout={{
-                      visibility:
-                        layer.isLayerOn && shouldRenderSedExportRaster ? 'visible' : 'none',
-                    }}
                   />
                 </Source>
               )

--- a/src/components/BaseMap/BaseMap.tsx
+++ b/src/components/BaseMap/BaseMap.tsx
@@ -887,7 +887,7 @@ export default function BaseMap({
                     type="raster"
                     key={`${layer.layerId}-${index}`}
                     source={layer.sourceId}
-                    beforeId="sediment_exposure_2000"
+                    beforeId="sed_dispersal"
                   />
                 </Source>
               )

--- a/src/components/BaseMap/BaseMap.tsx
+++ b/src/components/BaseMap/BaseMap.tsx
@@ -870,9 +870,7 @@ export default function BaseMap({
               layer.layerId !== 'sed_export' || sedExportSubLayerValue === 'pixel'
 
             return (
-              isMapLoaded &&
-              layer.isLayerOn &&
-              shouldRenderSedExportRaster && (
+              isMapLoaded && (
                 <Source
                   id={layer.sourceId}
                   key={`${layer.sourceId}-${index}`}
@@ -883,11 +881,15 @@ export default function BaseMap({
                   minzoom={6}
                 >
                   <Layer
-                    id={layer.layerId}
+                    id={layer.sourceId}
                     type="raster"
-                    key={`${layer.layerId}-${index}`}
+                    key={`${layer.sourceId}-${index}`}
                     source={layer.sourceId}
                     beforeId="sediment_exposure_2000"
+                    layout={{
+                      visibility:
+                        layer.isLayerOn && shouldRenderSedExportRaster ? 'visible' : 'none',
+                    }}
                   />
                 </Source>
               )

--- a/src/components/BaseMap/BaseMap.tsx
+++ b/src/components/BaseMap/BaseMap.tsx
@@ -579,8 +579,13 @@ export default function BaseMap({
       return
     }
 
-    // Clear the highlighted polygon from the previous plume layer before reselecting on the new one
-    if (previousPlumeLayer && previousPlumeLayer.sourceId !== plumeLayer.sourceId) {
+    // Clear the highlighted polygon from the previous plume layer before reselecting on the new one.
+    // Guard with getSource so we don't throw if the previous source was already unmounted (e.g. on year change).
+    if (
+      previousPlumeLayer &&
+      previousPlumeLayer.sourceId !== plumeLayer.sourceId &&
+      map.getSource(previousPlumeLayer.sourceId)
+    ) {
       clearPolygonSelect(map, plumeClickRef, previousPlumeLayer)
     }
 

--- a/src/components/BaseMap/BaseMap.tsx
+++ b/src/components/BaseMap/BaseMap.tsx
@@ -887,7 +887,7 @@ export default function BaseMap({
                     type="raster"
                     key={`${layer.layerId}-${index}`}
                     source={layer.sourceId}
-                    beforeId="sed_dispersal"
+                    beforeId="sediment_exposure_2000"
                   />
                 </Source>
               )

--- a/src/stores/mapStore.ts
+++ b/src/stores/mapStore.ts
@@ -65,15 +65,6 @@ export const useMapStore = create<MapState & MapActions>((set, get) => ({
 
     set({ sedExportMode: subLayerToggledOn, sedExportYear: selectedYear })
 
-    const pixelLayer = map.getLayer('sed_export')
-    if (pixelLayer) {
-      map.setLayoutProperty(
-        'sed_export',
-        'visibility',
-        subLayerToggledOn === 'pixel' ? 'visible' : 'none',
-      )
-    }
-
     const baseFillExpression =
       subLayerToggledOn === 'watershed'
         ? buildSedExportWatershedExpression(selectedYear)
@@ -93,11 +84,6 @@ export const useMapStore = create<MapState & MapActions>((set, get) => ({
     }
 
     set({ sedExportMode: null })
-
-    const pixelLayer = map.getLayer('sed_export')
-    if (pixelLayer) {
-      map.setLayoutProperty('sed_export', 'visibility', 'none')
-    }
 
     map.setPaintProperty(
       'watershed',


### PR DESCRIPTION
## Every PR

Before merging, the developer of this pull request has checked the following:

- [x] Changes have been tested locally without errors
- [x] Lint has run and any errors have been resolved
- [x] Prettier has run on any changed files
- [x] Storybook stories have run and any errors have been resolved
- [x] Pre-existing unit tests have run and passed
  - [ ] Unit tests have been added or updated, where possible, to prevent future regressions

## Post-Merge

- [ ] Code has merged and build success is confirmed in 'Actions'
- [ ] The corresponding Trello ticket has moved to the appropriate list (likely User-QA)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved map layer visibility handling so raster and tile layers display reliably across different modes and interaction states.

* **Performance**
  * Changed rendering to keep tile sources mounted and control visibility at the layer level, improving tile caching and reducing unnecessary reloads for smoother map responsiveness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->