### PR TITLE
feat: [C108] Add map tile loading indicator

### DIFF
--- a/src/components/BaseMap/BaseMap.module.scss
+++ b/src/components/BaseMap/BaseMap.module.scss
@@ -33,3 +33,17 @@
   font-weight: theme.$regular;
   padding-right: theme.$defaultSpacing;
 }
+
+.loading-snackbar-message {
+  display: inline-flex;
+  align-items: center;
+  gap: theme.$spacingSmall;
+}
+
+// `align-items: stretch` keeps the loading and error pills the same width.
+.snackbar-stack {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: theme.$spacingSmall;
+}

--- a/src/components/BaseMap/BaseMap.stories.ts
+++ b/src/components/BaseMap/BaseMap.stories.ts
@@ -31,6 +31,7 @@ export const Primary: Story = {
     },
     selectedYear: 2000,
     onMapMoveEnd: () => {},
+    isAnyDrawerOpen: false,
   },
   play: async ({ canvas }) => {
     // ensure story behaves as "desktop"
@@ -65,6 +66,7 @@ export const Loading: Story = {
     },
     selectedYear: 2000,
     onMapMoveEnd: () => {},
+    isAnyDrawerOpen: false,
   },
   // play: async ({ canvasElement }) => {
   //   const loadingText = i18next.t('loading')

--- a/src/components/BaseMap/BaseMap.tsx
+++ b/src/components/BaseMap/BaseMap.tsx
@@ -48,7 +48,7 @@ import {
   buildBenthicFillExpression,
 } from '../../utils/mapUtils'
 import { SourceDataEvent } from '../../types/MapLayerErrorTypes'
-import { Snackbar } from '@mui/material'
+import { CircularProgress, Snackbar, SnackbarContent } from '@mui/material'
 import { useTranslation } from 'react-i18next'
 import {
   mapFitBoundsDesktopConfig,
@@ -65,6 +65,9 @@ import { defaultGlobalRegionOption, regionOptions } from '../../data/regionData'
 import crosshairCursorUrl from '../../assets/crosshair-cursor.svg?url'
 
 const plumeCrosshairCursor = `url("${crosshairCursorUrl}") 10 10, crosshair`
+
+const trendsDrawerPeekHeight = 100
+const snackbarBottomGap = 36
 
 interface ApplyPlumeStatsParams {
   map: maplibregl.Map
@@ -104,6 +107,7 @@ interface BaseMapProps {
     zoom: number
   }
   onMapMoveEnd: (viewState: { latitude: number; longitude: number; zoom: number }) => void
+  isAnyDrawerOpen: boolean
 }
 
 const getRegionByLabel = (regionLabel: string | undefined) =>
@@ -375,9 +379,10 @@ export default function BaseMap({
   setBreadcrumb,
   initialViewState,
   onMapMoveEnd,
+  isAnyDrawerOpen,
 }: BaseMapProps) {
   const { t } = useTranslation()
-  const { isDesktopWidth } = useResponsive()
+  const { isDesktopWidth, isMobileWidth } = useResponsive()
 
   const setMapRef = useMapStore((s) => s.setMapRef)
   const clearTopPolygonsFill = useMapStore((s) => s.clearTopPolygonsFill)
@@ -408,8 +413,12 @@ export default function BaseMap({
   const [isMapLoaded, setIsMapLoaded] = useState(false)
 
   const [layerErrors, setLayerErrors] = useState<Record<string, string>>({})
+  const [isLoadingTiles, setIsLoadingTiles] = useState(false)
+  const [showLoadingIndicator, setShowLoadingIndicator] = useState(false)
 
   const mapLayersLoadingError = useMemo(() => Object.keys(layerErrors).length > 0, [layerErrors])
+  const showLoading = showLoadingIndicator && !(isMobileWidth && isAnyDrawerOpen)
+
   const watershedLayer = useMemo(
     () => mapLayers.find((l) => l.layerId === 'watershed'),
     [mapLayers],
@@ -601,17 +610,33 @@ export default function BaseMap({
     }
 
     const onError = (e) => handleError(e, setLayerErrors)
-    const onSourceData = (e) => handleSourceData(e, setLayerErrors)
+    const onSourceData = (e: SourceDataEvent) => handleSourceData(e, setLayerErrors)
+    const onSourceDataLoading = () => setIsLoadingTiles(true)
+    const onIdle = () => setIsLoadingTiles(false)
 
     map.on('error', onError)
     map.on('sourcedata', onSourceData)
+    map.on('sourcedataloading', onSourceDataLoading)
+    map.on('idle', onIdle)
 
     // eslint-disable-next-line consistent-return
     return () => {
       map.off('error', onError)
       map.off('sourcedata', onSourceData)
+      map.off('sourcedataloading', onSourceDataLoading)
+      map.off('idle', onIdle)
     }
   }, [isMapLoaded])
+
+  // 1s debounce: avoid flashing the indicator on fast loads.
+  useEffect(() => {
+    if (!isLoadingTiles) {
+      setShowLoadingIndicator(false)
+      return undefined
+    }
+    const timer = setTimeout(() => setShowLoadingIndicator(true), 1000)
+    return () => clearTimeout(timer)
+  }, [isLoadingTiles])
 
   // When selectedFeature is cleared externally (e.g., dropdown region change),
   // remove the watershed visual highlight from the map.
@@ -948,19 +973,46 @@ export default function BaseMap({
       </MapGL>
 
       <Snackbar
-        open={mapLayersLoadingError}
+        open={showLoading || mapLayersLoadingError}
         anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
-        message={t('map_layers_did_not_load')}
-        action={
-          <button
-            type="button"
-            className={styles['snackbar-reload-button']}
-            onClick={() => window.location.reload()}
-          >
-            {t('buttons.reload_page')}
-          </button>
-        }
-      />
+        // Mobile: clear the TrendsDrawer's bottom peek with a small gap.
+        sx={{
+          '&.MuiSnackbar-root': {
+            bottom: isMobileWidth ? `${trendsDrawerPeekHeight + snackbarBottomGap}px` : undefined,
+          },
+        }}
+      >
+        <div className={styles['snackbar-stack']}>
+          {showLoading && (
+            <SnackbarContent
+              message={
+                <span
+                  className={styles['loading-snackbar-message']}
+                  role="status"
+                  aria-live="polite"
+                >
+                  <CircularProgress size={16} color="inherit" aria-hidden />
+                  {t('map_layers_loading')}
+                </span>
+              }
+            />
+          )}
+          {mapLayersLoadingError && (
+            <SnackbarContent
+              message={t('map_layers_did_not_load')}
+              action={
+                <button
+                  type="button"
+                  className={styles['snackbar-reload-button']}
+                  onClick={() => window.location.reload()}
+                >
+                  {t('buttons.reload_page')}
+                </button>
+              }
+            />
+          )}
+        </div>
+      </Snackbar>
     </div>
   )
 }

--- a/src/components/BaseMap/BaseMap.tsx
+++ b/src/components/BaseMap/BaseMap.tsx
@@ -56,6 +56,8 @@ import {
   polygonHighlightWidth,
   polygonOutlineHoverColor,
   polygonOutlineSelectColor,
+  SNACKBAR_BOTTOM_GAP,
+  TRENDS_DRAWER_PEEK_HEIGHT,
 } from '../../constants'
 import { useSelectedFeatureStore } from '../../stores/selectedFeatureStore'
 import { LayerInfo, ZonalStatsBand } from '../../types/MapDataTypes'
@@ -65,9 +67,6 @@ import { defaultGlobalRegionOption, regionOptions } from '../../data/regionData'
 import crosshairCursorUrl from '../../assets/crosshair-cursor.svg?url'
 
 const plumeCrosshairCursor = `url("${crosshairCursorUrl}") 10 10, crosshair`
-
-const trendsDrawerPeekHeight = 100
-const snackbarBottomGap = 36
 
 interface ApplyPlumeStatsParams {
   map: maplibregl.Map
@@ -978,7 +977,9 @@ export default function BaseMap({
         // Mobile: clear the TrendsDrawer's bottom peek with a small gap.
         sx={{
           '&.MuiSnackbar-root': {
-            bottom: isMobileWidth ? `${trendsDrawerPeekHeight + snackbarBottomGap}px` : undefined,
+            bottom: isMobileWidth
+              ? `${TRENDS_DRAWER_PEEK_HEIGHT + SNACKBAR_BOTTOM_GAP}px`
+              : undefined,
           },
         }}
       >

--- a/src/components/LayersDrawer/LayersDrawer.stories.tsx
+++ b/src/components/LayersDrawer/LayersDrawer.stories.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import type { Meta, StoryObj } from '@storybook/react-vite'
 
 import LayersDrawer from './LayersDrawer'
@@ -18,6 +19,12 @@ export const Primary: Story = {
     onLayerToggleChange: () => {},
     onSedSubLayerChange: () => {},
     subSedLayerValue: 'pixel',
+    open: false,
+    onOpenChange: () => {},
+  },
+  render: (args) => {
+    const [open, setOpen] = useState(args.open)
+    return <LayersDrawer {...args} open={open} onOpenChange={setOpen} />
   },
 }
 

--- a/src/components/LayersDrawer/LayersDrawer.tsx
+++ b/src/components/LayersDrawer/LayersDrawer.tsx
@@ -1,4 +1,4 @@
-import { Dispatch, SetStateAction, useCallback, useMemo, useState } from 'react'
+import { Dispatch, SetStateAction, useCallback, useMemo } from 'react'
 import LayersIcon from '@mui/icons-material/Layers'
 import { useTranslation } from 'react-i18next'
 import { Card, Typography } from '@mui/material'
@@ -24,6 +24,8 @@ interface LayersDrawerProps {
   onLayerToggleChange: (toggledLayerId: string, isChecked: boolean) => void
   onSedSubLayerChange: (subLayerValue: 'pixel' | 'watershed') => void
   subSedLayerValue: 'pixel' | 'watershed'
+  open: boolean
+  onOpenChange: (open: boolean) => void
 }
 
 interface BoundaryLegendCardProps {
@@ -56,12 +58,13 @@ export default function LayersDrawer({
   onLayerToggleChange,
   onSedSubLayerChange,
   subSedLayerValue,
+  open,
+  onOpenChange,
 }: LayersDrawerProps) {
   const { t } = useTranslation()
-  const [open, setOpen] = useState(false)
 
   const toggleDrawer = (newOpen: boolean) => () => {
-    setOpen(newOpen)
+    onOpenChange(newOpen)
   }
 
   const mapSubLayers = useMemo(

--- a/src/components/MapContainer/MapContainer.tsx
+++ b/src/components/MapContainer/MapContainer.tsx
@@ -21,6 +21,7 @@ import {
 import { useMapStore } from '../../stores/mapStore'
 import { useSelectedFeatureStore } from '../../stores/selectedFeatureStore'
 import { defaultGlobalRegionOption } from '../../data/regionData'
+import useResponsive from '../../hooks/useResponsive'
 
 export default function MapContainer() {
   const toggleSedExportSubLayerFills = useMapStore((state) => state.toggleSedExportSubLayerFills)
@@ -65,9 +66,12 @@ export default function MapContainer() {
     getValidDispersalPoint(searchParams.get('dispersal-point')),
   )
 
+  const { isMobileWidth } = useResponsive()
   const [mapLayers, setMapLayers] = useState<LayerInfo[]>(layers)
   const [subSedLayerValue, setSubLayerValue] = useState<'pixel' | 'watershed'>('pixel')
   const [selectedRegion, setSelectedRegion] = useState<RegionOption>(initialRegion)
+  const [layersDrawerOpen, setLayersDrawerOpen] = useState(false)
+  const [trendsDrawerOpen, setTrendsDrawerOpen] = useState(!isMobileWidth)
   const [breadcrumb, setBreadcrumb] = useState<RegionOption[]>(
     initialRegion.regionType !== 'global'
       ? [defaultGlobalRegionOption, initialRegion]
@@ -313,6 +317,8 @@ export default function MapContainer() {
           onLayerToggleChange={handleLayerToggleChange}
           onSedSubLayerChange={handleSedSubLayerChange}
           subSedLayerValue={subSedLayerValue}
+          open={layersDrawerOpen}
+          onOpenChange={setLayersDrawerOpen}
         />
         <RegionSelect
           selectedRegion={selectedRegion}
@@ -321,7 +327,12 @@ export default function MapContainer() {
           setBreadcrumb={setBreadcrumb}
         />
         <YearSelect selectedYear={selectedYear} onChange={handleYearChange} />
-        <TrendsDrawer selectedRegion={selectedRegion} selectedYear={selectedYear} />
+        <TrendsDrawer
+          selectedRegion={selectedRegion}
+          selectedYear={selectedYear}
+          open={trendsDrawerOpen}
+          onOpenChange={setTrendsDrawerOpen}
+        />
       </div>
       <BaseMap
         mapLayers={urlSyncedMapLayers}
@@ -341,6 +352,7 @@ export default function MapContainer() {
           zoom: zoom ?? selectedRegion.zoomLevel,
         }}
         onMapMoveEnd={handleMapMoveEnd}
+        isAnyDrawerOpen={layersDrawerOpen || trendsDrawerOpen}
       />
     </div>
   )

--- a/src/components/TrendsDrawer/TrendsDrawer.stories.tsx
+++ b/src/components/TrendsDrawer/TrendsDrawer.stories.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import type { Meta, StoryObj } from '@storybook/react-vite'
 
 import TrendsDrawer from './TrendsDrawer'
@@ -13,6 +14,12 @@ export const Primary: Story = {
   args: {
     selectedRegion: defaultGlobalRegionOption,
     selectedYear: 2020,
+    open: true,
+    onOpenChange: () => {},
+  },
+  render: (args) => {
+    const [open, setOpen] = useState(args.open)
+    return <TrendsDrawer {...args} open={open} onOpenChange={setOpen} />
   },
 }
 

--- a/src/components/TrendsDrawer/TrendsDrawer.tsx
+++ b/src/components/TrendsDrawer/TrendsDrawer.tsx
@@ -14,6 +14,7 @@ import { MapGeoJSONFeature } from 'maplibre-gl'
 
 import { useSelectedFeatureStore } from '../../stores/selectedFeatureStore'
 import { chartsByRegionType } from '../../data/chartSeriesData'
+import { TRENDS_DRAWER_PEEK_HEIGHT } from '../../constants'
 import { fetchBoundaryProperties } from '../../utils/pmtilesUtils'
 import {
   buildChartDataFromProperties,
@@ -113,7 +114,7 @@ export default function TrendsDrawer({
       open={open}
       onOpen={openDrawer}
       onClose={closeDrawer}
-      swipeAreaWidth={100}
+      swipeAreaWidth={TRENDS_DRAWER_PEEK_HEIGHT}
     >
       <div className={styles['drawer-header']}>
         {open && <h2 style={{ marginTop: '4px' }}>{t(drawerTitle)}</h2>}

--- a/src/components/TrendsDrawer/TrendsDrawer.tsx
+++ b/src/components/TrendsDrawer/TrendsDrawer.tsx
@@ -27,14 +27,20 @@ import {
 interface TrendsDrawerProps {
   selectedRegion: RegionOption
   selectedYear: number
+  open: boolean
+  onOpenChange: (open: boolean) => void
 }
 
-export default function TrendsDrawer({ selectedRegion, selectedYear }: TrendsDrawerProps) {
+export default function TrendsDrawer({
+  selectedRegion,
+  selectedYear,
+  open,
+  onOpenChange,
+}: TrendsDrawerProps) {
   const { t } = useTranslation()
   const { isMobileWidth } = useResponsive()
-  const [open, setOpen] = useState(!isMobileWidth)
-  const openDrawer = () => setOpen(true)
-  const closeDrawer = () => setOpen(false)
+  const openDrawer = () => onOpenChange(true)
+  const closeDrawer = () => onOpenChange(false)
   const [chartConfigData, setChartConfigData] = useState<ChartProperties[] | null>(
     tempGlobalChartSeriesData,
   )

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -96,3 +96,7 @@ export const polygonOutlineHoverColor = '#00FF01'
 export const polygonOutlineSelectColor = '#0000FF'
 export const polygonHighlightWidth = 3
 export const topContributingWatershedColorFills = ['#FFA600', '#D86D83', '#7A5195']
+
+/******LAYOUT******/
+export const TRENDS_DRAWER_PEEK_HEIGHT = 100
+export const SNACKBAR_BOTTOM_GAP = 36

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -118,5 +118,6 @@
   "toggle_navigation_menu": "Toggle navigation menu",
   "select_year": "Select year",
   "map_layers_did_not_load": "Some map layers didn't load",
+  "map_layers_loading": "Loading map layers...",
   "ocean_pollution": "Ocean Pollution"
 }


### PR DESCRIPTION
## Summary

- Detect tile fetches via MapLibre `sourcedataloading`, `sourcedata`, and `idle` events. Debounce the indicator by 1s so fast loads don't flash the UI.
- Render a `SnackbarContent` with MUI `CircularProgress` for the loading state. Stack vertically above the existing "didn't load" snackbar at matching width.
- On mobile (<=1024px), move the Snackbar above the TrendsDrawer's bottom peek and hide the loading snackbar when the Layers or Trends drawer is open.
- `LayersDrawer` and `TrendsDrawer` are controlled; `MapContainer` owns their open state and passes a single `isAnyDrawerOpen` flag to `BaseMap`.

## Test plan

### Desktop (>1024px)

- [ ] Throttle network to "Slow 4G" in DevTools. Pan/zoom around Fiji. The loading snackbar should appear after ~1s and clear once tiles settle.
- [ ] Without throttling, quick pans should NOT flash the snackbar (1s debounce) unless you do a lot in quick succession.
- [ ] If a tile request fails, the error snackbar appears with "Reload page". Trigger another pan; the loading snackbar stacks with the error one.

### Mobile (<=1024px, DevTools device emulation)

- [ ] Throttled pan/zoom around Fiji: loading snackbar sits above the TrendsDrawer peek, not under it.
- [ ] Open the TrendsDrawer (swipe up). Loader hides while open; reappears on close if tiles are still loading.
- [ ] Open the LayersDrawer (left). Same hide-while-open behaviour.

## Every PR

Before merging, the developer of this pull request has checked the following:

- [ ] Changes have been tested locally without errors
- [ ] Lint has run and any errors have been resolved
- [ ] Prettier has run on any changed files
- [ ] Storybook stories have run and any errors have been resolved
- [ ] Pre-existing unit tests have run and passed
  - [ ] Unit tests have been added or updated, where possible, to prevent future regressions

## Post-Merge

- [ ] Code has merged and build success is confirmed in 'Actions'
- [ ] The corresponding Trello ticket has moved to the appropriate list (likely User-QA)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Map now displays a loading indicator while tiles are being fetched, showing a "Loading map layers..." message.

* **Improvements**
  * Optimized loading snackbar positioning on mobile to prevent overlap with drawer UI.
  * Reduced visual flicker through debounced loading state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->