### PR TITLE
fix: [C185] Set pointer cursor on watershed hover

### DIFF
--- a/src/components/BaseMap/BaseMap.tsx
+++ b/src/components/BaseMap/BaseMap.tsx
@@ -816,6 +816,7 @@ export default function BaseMap({
     }
 
     const onWatershedHover = (e: MapLayerMouseEvent) => {
+      map.getCanvas().style.cursor = 'pointer'
       polygonHoverHandler(map, e, watershedLayer)
     }
     const onWatershedClick = (e: MapLayerMouseEvent) => {
@@ -853,9 +854,6 @@ export default function BaseMap({
     polygonClickBoundRef.current = onWatershedClick
     map.on('click', 'watershed', onWatershedClick)
     map.on('mousemove', 'watershed', onWatershedHover)
-    map.on('mouseenter', 'watershed', () => {
-      map.getCanvas().style.cursor = 'pointer'
-    })
     map.on('mouseleave', 'watershed', () => {
       map.getCanvas().style.cursor = ''
       clearPolygonHover(map, polygonHoverRef, watershedLayer)


### PR DESCRIPTION
## Every PR

Before merging, the developer of this pull request has checked the following:

- [ ] Changes have been tested locally without errors
- [ ] Lint has run and any errors have been resolved
- [ ] Prettier has run on any changed files
- [ ] Storybook stories have run and any errors have been resolved
- [ ] Pre-existing unit tests have run and passed
  - [ ] Unit tests have been added or updated, where possible, to prevent future regressions

## Post-Merge

- [ ] Code has merged and build success is confirmed in 'Actions'
- [ ] The corresponding Trello ticket has moved to the appropriate list (likely User-QA)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized cursor interaction handling for watershed map elements, streamlining hover state management for improved efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->