### PR TITLE
fix: [C184] Skip fitBounds on watershed click 

### DIFF
--- a/src/components/BaseMap/BaseMap.tsx
+++ b/src/components/BaseMap/BaseMap.tsx
@@ -519,7 +519,10 @@ export default function BaseMap({
 
   const polygonHoverHandler = useMemo(() => createPolygonHoverHandler(polygonHoverRef), [])
   const polygonClickHandler = useMemo(
-    () => createPolygonClickHandler(polygonClickRef, handleFeatureSelect),
+    () =>
+      createPolygonClickHandler(polygonClickRef, (feature, bounds) =>
+        handleFeatureSelect(feature, bounds, { skipFitBounds: true }),
+      ),
     [handleFeatureSelect],
   )
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -86,7 +86,7 @@ export const ZOOM_PRECISION = 2
 /******MAP FIT BOUNDS******/
 export const mapFitBoundsDesktopConfig = {
   padding: { top: 300, bottom: 300, left: 300, right: 300 },
-  maxZoom: 14,
+  maxZoom: 10,
 }
 
 export const mapFitBoundsMobileConfig = {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -86,7 +86,7 @@ export const ZOOM_PRECISION = 2
 /******MAP FIT BOUNDS******/
 export const mapFitBoundsDesktopConfig = {
   padding: { top: 300, bottom: 300, left: 300, right: 300 },
-  maxZoom: 10,
+  maxZoom: 14,
 }
 
 export const mapFitBoundsMobileConfig = {


### PR DESCRIPTION
Pass skipFitBounds: true from the polygon click handler so clicking
a watershed selects it without moving the camera. URL-restore still
fits when no explicit lat/lng/zoom is present.

## Every PR

Before merging, the developer of this pull request has checked the following:

- [ ] Changes have been tested locally without errors
- [ ] Lint has run and any errors have been resolved
- [ ] Prettier has run on any changed files
- [ ] Storybook stories have run and any errors have been resolved
- [ ] Pre-existing unit tests have run and passed
  - [ ] Unit tests have been added or updated, where possible, to prevent future regressions

## Post-Merge

- [ ] Code has merged and build success is confirmed in 'Actions'
- [ ] The corresponding Trello ticket has moved to the appropriate list (likely User-QA)
