### PR TITLE
enhance: [C172] Utility functions unit test

### DIFF
--- a/src/tests/chartUtils.test.ts
+++ b/src/tests/chartUtils.test.ts
@@ -207,8 +207,6 @@ describe('chart data utilities', () => {
     }
 
     beforeEach(() => {
-      jest.clearAllMocks()
-
       Object.assign(chartSeriesConfig, mockChartSeriesConfig)
 
       const mockTranslate = jest.fn((key: string) => {
@@ -527,76 +525,50 @@ const sharedPlumeMockConfig = {
   },
 }
 
-// ---------------------------------------------------------------------------
-// getRegionLabel
-// ---------------------------------------------------------------------------
 describe('getRegionLabel', () => {
-  const mockRegion = { label: 'Pacific Region' } as ReturnType<() => { label: string }>
+  const mockRegion = { label: 'Pacific Region' } as never
 
-  it("returns an empty string for 'global' region type", () => {
-    expect(getRegionLabel('global', mockRegion as never, null)).toBe('')
-  })
-
-  it("returns String(feature.id) for 'watershed' region type", () => {
-    const feature = { id: 42 } as unknown as MapGeoJSONFeature
-    expect(getRegionLabel('watershed', mockRegion as never, feature)).toBe('42')
-  })
-
-  it("returns empty string when feature is null for 'watershed' region type", () => {
-    expect(getRegionLabel('watershed', mockRegion as never, null)).toBe('')
-  })
-
-  it('returns selectedRegion.label for non-global, non-watershed region types', () => {
-    expect(getRegionLabel('country', mockRegion as never, null)).toBe('Pacific Region')
-
-    expect(getRegionLabel('region', mockRegion as never, null)).toBe('Pacific Region')
+  it.each([
+    { regionType: 'global', feature: null, expected: '' },
+    { regionType: 'watershed', feature: { id: 42 }, expected: '42' },
+    { regionType: 'watershed', feature: null, expected: '' },
+    { regionType: 'country', feature: null, expected: 'Pacific Region' },
+    { regionType: 'region', feature: null, expected: 'Pacific Region' },
+  ])('$regionType → "$expected"', ({ regionType, feature, expected }) => {
+    expect(getRegionLabel(regionType as never, mockRegion, feature as never)).toBe(expected)
   })
 })
 
-// ---------------------------------------------------------------------------
-// getDrawerTitle
-// ---------------------------------------------------------------------------
 describe('getDrawerTitle', () => {
-  it("returns 'global_trends' for 'global'", () => {
-    expect(getDrawerTitle('global', 'fallback')).toBe('global_trends')
-  })
-
-  it("returns 'watershed_information' for 'watershed'", () => {
-    expect(getDrawerTitle('watershed', 'fallback')).toBe('watershed_information')
-  })
-
-  it("returns 'ocean_pollution' for 'plume'", () => {
-    expect(getDrawerTitle('plume', 'fallback')).toBe('ocean_pollution')
-  })
-
-  it('returns fallbackLabel for any other region type', () => {
-    expect(getDrawerTitle('country', 'country_details')).toBe('country_details')
-    expect(getDrawerTitle('region', 'region_overview')).toBe('region_overview')
+  it.each([
+    ['global', 'fallback', 'global_trends'],
+    ['watershed', 'fallback', 'watershed_information'],
+    ['plume', 'fallback', 'ocean_pollution'],
+    ['country', 'country_details', 'country_details'],
+    ['region', 'region_overview', 'region_overview'],
+  ] as const)('(%s, %s) → %s', (regionType, fallback, expected) => {
+    expect(getDrawerTitle(regionType, fallback)).toBe(expected)
   })
 })
 
-// ---------------------------------------------------------------------------
-// getEffectiveRegionType
-// ---------------------------------------------------------------------------
 describe('getEffectiveRegionType', () => {
-  it("returns 'plume' when plumeWatershedStats are present", () => {
-    const stats = { 1: { band_1: { majority: 5, aoi_area: 0, data_area: 0 } } }
-    expect(getEffectiveRegionType(stats, undefined, 'region')).toBe('plume')
-  })
+  const stats = { 1: { band_1: { majority: 5, aoi_area: 0, data_area: 0 } } }
 
-  it("returns 'watershed' when stats are absent but source is 'watershed_src'", () => {
-    expect(getEffectiveRegionType(null, 'watershed_src', 'region')).toBe('watershed')
-  })
-
-  it('returns the passed regionType when neither condition matches', () => {
-    expect(getEffectiveRegionType(null, 'countries_src', 'region')).toBe('region')
-    expect(getEffectiveRegionType(null, undefined, 'global')).toBe('global')
-  })
+  it.each([
+    { plumeStats: stats, source: undefined, regionType: 'region', expected: 'plume' },
+    { plumeStats: null, source: 'watershed_src', regionType: 'region', expected: 'watershed' },
+    { plumeStats: null, source: 'countries_src', regionType: 'region', expected: 'region' },
+    { plumeStats: null, source: undefined, regionType: 'global', expected: 'global' },
+  ])(
+    '(source=$source, type=$regionType) → $expected',
+    ({ plumeStats, source, regionType, expected }) => {
+      expect(getEffectiveRegionType(plumeStats as never, source, regionType as never)).toBe(
+        expected,
+      )
+    },
+  )
 })
 
-// ---------------------------------------------------------------------------
-// getUpOneLevelLabel
-// ---------------------------------------------------------------------------
 describe('getUpOneLevelLabel', () => {
   const mockRegion = { label: 'Solomon Islands' } as never
 
@@ -605,26 +577,18 @@ describe('getUpOneLevelLabel', () => {
     i18next.t = (key: string) => key
   })
 
-  it("returns selectedRegion.label for 'plume'", () => {
-    expect(getUpOneLevelLabel('plume', mockRegion)).toBe('Solomon Islands')
-  })
-
-  it("returns selectedRegion.label for 'watershed'", () => {
-    expect(getUpOneLevelLabel('watershed', mockRegion)).toBe('Solomon Islands')
-  })
-
-  it("returns the i18next key 'regions.global' for non-plume / non-watershed types", () => {
-    expect(getUpOneLevelLabel('global', mockRegion)).toBe('regions.global')
-    expect(getUpOneLevelLabel('country', mockRegion)).toBe('regions.global')
+  it.each([
+    ['plume', 'Solomon Islands'],
+    ['watershed', 'Solomon Islands'],
+    ['global', 'regions.global'],
+    ['country', 'regions.global'],
+  ] as const)('%s → "%s"', (regionType, expected) => {
+    expect(getUpOneLevelLabel(regionType, mockRegion)).toBe(expected)
   })
 })
 
-// ---------------------------------------------------------------------------
-// buildChartDataFromProperties
-// ---------------------------------------------------------------------------
 describe('buildChartDataFromProperties', () => {
   beforeEach(() => {
-    jest.clearAllMocks()
     Object.assign(chartSeriesConfig, sharedLandUseMockConfig)
     // @ts-expect-error mocking i18next.t
     i18next.t = (key: string) => key
@@ -646,12 +610,8 @@ describe('buildChartDataFromProperties', () => {
   })
 })
 
-// ---------------------------------------------------------------------------
-// updateChartData
-// ---------------------------------------------------------------------------
 describe('updateChartData', () => {
   beforeEach(() => {
-    jest.clearAllMocks()
     Object.assign(chartSeriesConfig, sharedLandUseMockConfig)
     // @ts-expect-error mocking i18next.t
     i18next.t = (key: string) => key
@@ -684,9 +644,6 @@ describe('updateChartData', () => {
   })
 })
 
-// ---------------------------------------------------------------------------
-// mapChartConfigToPlumeData
-// ---------------------------------------------------------------------------
 describe('mapChartConfigToPlumeData', () => {
   const plumeStats = {
     '2020': {
@@ -698,7 +655,6 @@ describe('mapChartConfigToPlumeData', () => {
   }
 
   beforeEach(() => {
-    jest.clearAllMocks()
     Object.assign(chartSeriesConfig, sharedPlumeMockConfig)
     // @ts-expect-error mocking i18next.t
     i18next.t = (key: string) => key
@@ -733,9 +689,6 @@ describe('mapChartConfigToPlumeData', () => {
   })
 })
 
-// ---------------------------------------------------------------------------
-// updatePlumeChartData
-// ---------------------------------------------------------------------------
 describe('updatePlumeChartData', () => {
   const plumeStats = {
     '2020': {
@@ -747,7 +700,6 @@ describe('updatePlumeChartData', () => {
   }
 
   beforeEach(() => {
-    jest.clearAllMocks()
     Object.assign(chartSeriesConfig, sharedPlumeMockConfig)
     // @ts-expect-error mocking i18next.t
     i18next.t = (key: string) => key

--- a/src/tests/chartUtils.test.ts
+++ b/src/tests/chartUtils.test.ts
@@ -477,29 +477,6 @@ describe('export filename utilities', () => {
       )
     })
   })
-
-  describe('getRegionLabel', () => {
-    const mockRegion = { label: 'Pacific Region' } as ReturnType<() => { label: string }>
-
-    it("returns an empty string for 'global' region type", () => {
-      expect(getRegionLabel('global', mockRegion as never, null)).toBe('')
-    })
-
-    it("returns String(feature.id) for 'watershed' region type", () => {
-      const feature = { id: 42 } as unknown as MapGeoJSONFeature
-      expect(getRegionLabel('watershed', mockRegion as never, feature)).toBe('42')
-    })
-
-    it("returns empty string when feature is null for 'watershed' region type", () => {
-      expect(getRegionLabel('watershed', mockRegion as never, null)).toBe('')
-    })
-
-    it('returns selectedRegion.label for non-global, non-watershed region types', () => {
-      expect(getRegionLabel('country', mockRegion as never, null)).toBe('Pacific Region')
-
-      expect(getRegionLabel('region', mockRegion as never, null)).toBe('Pacific Region')
-    })
-  })
 })
 
 // ---------------------------------------------------------------------------

--- a/src/tests/chartUtils.test.ts
+++ b/src/tests/chartUtils.test.ts
@@ -4,10 +4,19 @@ import {
   mapChartConfigToData,
   formatForFilename,
   buildExportFilename,
+  getRegionLabel,
+  getDrawerTitle,
+  getEffectiveRegionType,
+  getUpOneLevelLabel,
+  buildChartDataFromProperties,
+  updateChartData,
+  mapChartConfigToPlumeData,
+  updatePlumeChartData,
 } from '../utils/chartUtils'
 import { ChartData, ChartSeriesName } from '../types/ChartDataTypes'
 import { chartSeriesConfig } from '../data/chartSeriesData'
 import i18next from 'i18next'
+import { MapGeoJSONFeature } from 'maplibre-gl'
 
 const groupedProperties: LulcAndSedimentSeriesData = {
   land_use_historical: {
@@ -467,5 +476,315 @@ describe('export filename utilities', () => {
         'global-ecosystem-extent-exposed-to-pollution',
       )
     })
+  })
+
+  describe('getRegionLabel', () => {
+    const mockRegion = { label: 'Pacific Region' } as ReturnType<() => { label: string }>
+
+    it("returns an empty string for 'global' region type", () => {
+      expect(getRegionLabel('global', mockRegion as never, null)).toBe('')
+    })
+
+    it("returns String(feature.id) for 'watershed' region type", () => {
+      const feature = { id: 42 } as unknown as MapGeoJSONFeature
+      expect(getRegionLabel('watershed', mockRegion as never, feature)).toBe('42')
+    })
+
+    it("returns empty string when feature is null for 'watershed' region type", () => {
+      expect(getRegionLabel('watershed', mockRegion as never, null)).toBe('')
+    })
+
+    it('returns selectedRegion.label for non-global, non-watershed region types', () => {
+      expect(getRegionLabel('country', mockRegion as never, null)).toBe('Pacific Region')
+
+      expect(getRegionLabel('region', mockRegion as never, null)).toBe('Pacific Region')
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Shared mock config used by the new test suites below
+// ---------------------------------------------------------------------------
+const sharedLandUseMockConfig = {
+  'charts.land_use_historical': {
+    xAxisTitle: 'chart_information.year',
+    yAxisTitle: 'chart_information.land_cover',
+    legendColors: {
+      bare_ground: '#D4A373',
+      cropland: '#FFD700',
+    },
+    width: 0.8,
+    barmode: 'stack',
+    tracePrefix: 'land_use',
+  },
+  'charts.sediment_load_historical': {
+    xAxisTitle: 'chart_information.year',
+    yAxisTitle: 'chart_information.sediment_export',
+    legendColors: { sediment: '#8B4513' },
+    width: 0.6,
+    barmode: 'group',
+  },
+  'charts.ecosystem_extent_exposed': {
+    xAxisTitle: 'chart_information.year',
+    yAxisTitle: 'chart_information.ecosystem_extent',
+    legendColors: { reef_extent: '#0077B6', coral_algae: '#48CAE4', seagrass: '#90E0EF' },
+    width: 0.8,
+    barmode: 'stack',
+  },
+}
+
+const sharedPlumeMockConfig = {
+  'charts.sediment_exposure_historical': {
+    xAxisTitle: 'chart_information.year',
+    yAxisTitle: 'chart_information.sediment_exposure',
+    legendColors: { sediment: '#8B4513' },
+    width: 0.6,
+    barmode: 'group',
+  },
+  'charts.contributing_watersheds': {
+    xAxisTitle: 'chart_information.year',
+    yAxisTitle: 'chart_information.watersheds',
+    legendColors: { w1: '#aabbcc', w2: '#bbccdd', w3: '#ccddee' },
+    width: 0.8,
+    barmode: 'stack',
+  },
+}
+
+// ---------------------------------------------------------------------------
+// getRegionLabel
+// ---------------------------------------------------------------------------
+describe('getRegionLabel', () => {
+  const mockRegion = { label: 'Pacific Region' } as ReturnType<() => { label: string }>
+
+  it("returns an empty string for 'global' region type", () => {
+    expect(getRegionLabel('global', mockRegion as never, null)).toBe('')
+  })
+
+  it("returns String(feature.id) for 'watershed' region type", () => {
+    const feature = { id: 42 } as unknown as MapGeoJSONFeature
+    expect(getRegionLabel('watershed', mockRegion as never, feature)).toBe('42')
+  })
+
+  it("returns empty string when feature is null for 'watershed' region type", () => {
+    expect(getRegionLabel('watershed', mockRegion as never, null)).toBe('')
+  })
+
+  it('returns selectedRegion.label for non-global, non-watershed region types', () => {
+    expect(getRegionLabel('country', mockRegion as never, null)).toBe('Pacific Region')
+
+    expect(getRegionLabel('region', mockRegion as never, null)).toBe('Pacific Region')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// getDrawerTitle
+// ---------------------------------------------------------------------------
+describe('getDrawerTitle', () => {
+  it("returns 'global_trends' for 'global'", () => {
+    expect(getDrawerTitle('global', 'fallback')).toBe('global_trends')
+  })
+
+  it("returns 'watershed_information' for 'watershed'", () => {
+    expect(getDrawerTitle('watershed', 'fallback')).toBe('watershed_information')
+  })
+
+  it("returns 'ocean_pollution' for 'plume'", () => {
+    expect(getDrawerTitle('plume', 'fallback')).toBe('ocean_pollution')
+  })
+
+  it('returns fallbackLabel for any other region type', () => {
+    expect(getDrawerTitle('country', 'country_details')).toBe('country_details')
+    expect(getDrawerTitle('region', 'region_overview')).toBe('region_overview')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// getEffectiveRegionType
+// ---------------------------------------------------------------------------
+describe('getEffectiveRegionType', () => {
+  it("returns 'plume' when plumeWatershedStats are present", () => {
+    const stats = { 1: { band_1: { majority: 5, aoi_area: 0, data_area: 0 } } }
+    expect(getEffectiveRegionType(stats, undefined, 'region')).toBe('plume')
+  })
+
+  it("returns 'watershed' when stats are absent but source is 'watershed_src'", () => {
+    expect(getEffectiveRegionType(null, 'watershed_src', 'region')).toBe('watershed')
+  })
+
+  it('returns the passed regionType when neither condition matches', () => {
+    expect(getEffectiveRegionType(null, 'countries_src', 'region')).toBe('region')
+    expect(getEffectiveRegionType(null, undefined, 'global')).toBe('global')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// getUpOneLevelLabel
+// ---------------------------------------------------------------------------
+describe('getUpOneLevelLabel', () => {
+  const mockRegion = { label: 'Solomon Islands' } as never
+
+  beforeEach(() => {
+    // @ts-expect-error mocking i18next.t
+    i18next.t = (key: string) => key
+  })
+
+  it("returns selectedRegion.label for 'plume'", () => {
+    expect(getUpOneLevelLabel('plume', mockRegion)).toBe('Solomon Islands')
+  })
+
+  it("returns selectedRegion.label for 'watershed'", () => {
+    expect(getUpOneLevelLabel('watershed', mockRegion)).toBe('Solomon Islands')
+  })
+
+  it("returns the i18next key 'regions.global' for non-plume / non-watershed types", () => {
+    expect(getUpOneLevelLabel('global', mockRegion)).toBe('regions.global')
+    expect(getUpOneLevelLabel('country', mockRegion)).toBe('regions.global')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// buildChartDataFromProperties
+// ---------------------------------------------------------------------------
+describe('buildChartDataFromProperties', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    Object.assign(chartSeriesConfig, sharedLandUseMockConfig)
+    // @ts-expect-error mocking i18next.t
+    i18next.t = (key: string) => key
+  })
+
+  it('returns a ChartProperties array when properties contain recognisable LULC data', () => {
+    const result = buildChartDataFromProperties({ Bare_Gr_pct_2000: 5, Bare_Gr_pct_2005: 8 })
+
+    expect(Array.isArray(result)).toBe(true)
+    expect(result).not.toBeNull()
+    expect(result!.length).toBeGreaterThan(0)
+    expect(result![0].chartName).toBe('land_use_historical')
+  })
+
+  it('returns null when no recognisable properties are present', () => {
+    const result = buildChartDataFromProperties({ name: 'Test', watershed_id: 99 })
+
+    expect(result).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// updateChartData
+// ---------------------------------------------------------------------------
+describe('updateChartData', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    Object.assign(chartSeriesConfig, sharedLandUseMockConfig)
+    // @ts-expect-error mocking i18next.t
+    i18next.t = (key: string) => key
+  })
+
+  it('calls setChartData with chart data for a recognised source', () => {
+    const feature = {
+      source: 'countries_src',
+      properties: { Bare_Gr_pct_2000: 5 },
+    } as unknown as MapGeoJSONFeature
+
+    const setChartData = jest.fn()
+    updateChartData(feature, setChartData)
+
+    expect(setChartData).toHaveBeenCalledTimes(1)
+    const arg = setChartData.mock.calls[0][0]
+    expect(Array.isArray(arg)).toBe(true)
+  })
+
+  it('calls setChartData with null for an unrecognised source', () => {
+    const feature = {
+      source: 'unknown_src',
+      properties: { Bare_Gr_pct_2000: 5 },
+    } as unknown as MapGeoJSONFeature
+
+    const setChartData = jest.fn()
+    updateChartData(feature, setChartData)
+
+    expect(setChartData).toHaveBeenCalledWith(null)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// mapChartConfigToPlumeData
+// ---------------------------------------------------------------------------
+describe('mapChartConfigToPlumeData', () => {
+  const plumeStats = {
+    '2020': {
+      band_1: { majority: 5, aoi_area: 0, data_area: 0 },
+      band_5: { majority: 10, aoi_area: 0, data_area: 0 },
+      band_6: { majority: 20, aoi_area: 0, data_area: 0 },
+      band_7: { majority: 30, aoi_area: 0, data_area: 0 },
+    },
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    Object.assign(chartSeriesConfig, sharedPlumeMockConfig)
+    // @ts-expect-error mocking i18next.t
+    i18next.t = (key: string) => key
+  })
+
+  it('returns exactly two ChartProperties entries', () => {
+    const result = mapChartConfigToPlumeData(Object.entries(plumeStats))
+
+    expect(result).toHaveLength(2)
+  })
+
+  it('first entry is sediment_exposure_historical with correct structure', () => {
+    const result = mapChartConfigToPlumeData(Object.entries(plumeStats))
+    const sedChart = result[0]
+
+    expect(sedChart.chartName).toBe('sediment_exposure_historical')
+    expect(sedChart.chartSeriesData).toHaveLength(1)
+    expect(sedChart.chartSeriesData[0].x).toEqual(['2020'])
+    expect(sedChart.chartSeriesData[0].y).toEqual([5])
+  })
+
+  it('second entry is contributing_watersheds with three reversed watershed bars', () => {
+    const result = mapChartConfigToPlumeData(Object.entries(plumeStats))
+    const watershedChart = result[1]
+
+    expect(watershedChart.chartName).toBe('contributing_watersheds')
+    // bands are reversed: w3 (band_7=30), w2 (band_6=20), w1 (band_5=10)
+    expect(watershedChart.chartSeriesData).toHaveLength(3)
+    expect(watershedChart.chartSeriesData[0].y).toEqual([30])
+    expect(watershedChart.chartSeriesData[1].y).toEqual([20])
+    expect(watershedChart.chartSeriesData[2].y).toEqual([10])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// updatePlumeChartData
+// ---------------------------------------------------------------------------
+describe('updatePlumeChartData', () => {
+  const plumeStats = {
+    '2020': {
+      band_1: { majority: 5, aoi_area: 0, data_area: 0 },
+      band_5: { majority: 10, aoi_area: 0, data_area: 0 },
+      band_6: { majority: 20, aoi_area: 0, data_area: 0 },
+      band_7: { majority: 30, aoi_area: 0, data_area: 0 },
+    },
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    Object.assign(chartSeriesConfig, sharedPlumeMockConfig)
+    // @ts-expect-error mocking i18next.t
+    i18next.t = (key: string) => key
+  })
+
+  it('calls setChartData with the two mapped ChartProperties', () => {
+    const setChartData = jest.fn()
+    updatePlumeChartData(plumeStats, setChartData)
+
+    expect(setChartData).toHaveBeenCalledTimes(1)
+    const arg = setChartData.mock.calls[0][0]
+    expect(Array.isArray(arg)).toBe(true)
+    expect(arg).toHaveLength(2)
+    expect(arg[0].chartName).toBe('sediment_exposure_historical')
+    expect(arg[1].chartName).toBe('contributing_watersheds')
   })
 })

--- a/src/tests/mapUtils.test.ts
+++ b/src/tests/mapUtils.test.ts
@@ -568,6 +568,12 @@ describe('map utilities', () => {
       const body = JSON.parse(options!.body as string)
       expect(body.url).toBe(SEDIMENT_EXPOSURE_2000_URL)
     })
+
+    it('throws with a descriptive error for an unmapped year', async () => {
+      await expect(prepareZonalStatsCall({ lng: 179.0, lat: -18.0 }, 1999)).rejects.toThrow(
+        'No sediment exposure URL available for year: 1999',
+      )
+    })
   })
 
   describe('getAllYearZonalStats', () => {

--- a/src/tests/mapUtils.test.ts
+++ b/src/tests/mapUtils.test.ts
@@ -1,17 +1,38 @@
 import {
+  buildBenthicFillExpression,
   buildSedExportWatershedExpression,
   buildWatershedMatchExpression,
+  calculateFeatureBounds,
+  clearPolygonHover,
+  clearPolygonSelect,
   createPolygonClickHandler,
   createPolygonHoverHandler,
   getActiveLayers,
+  getAllYearZonalStats,
+  getUpdatedBenthicColor,
   mapRegionSelected,
+  mapToggleChange,
+  postZonalStats,
+  prepareZonalStatsCall,
+  querySourceFeatureAtPointWhenReady,
+  querySourceFeatureWhenReady,
+  resolveBasemapBeforeId,
+  setPolygonSelect,
 } from '../utils/mapUtils'
-import { Map, MapGeoJSONFeature, MapLayerMouseEvent } from 'maplibre-gl'
+import { FilterSpecification, Map, MapGeoJSONFeature, MapLayerMouseEvent } from 'maplibre-gl'
 import { RefObject } from 'react'
 import { regionOptions } from '../data/regionData'
-import { sedExportColorMapping, transparent } from '../data/mapData'
-import { topContributingWatershedColorFills } from '../constants'
+import { atlasBenthicColors, sedExportColorMapping, transparent } from '../data/mapData'
+import {
+  BASE_ZONAL_STATS_API,
+  SEDIMENT_EXPOSURE_2000_URL,
+  SEDIMENT_EXPOSURE_2020_URL,
+  topContributingWatershedColorFills,
+} from '../constants'
 import { LayerInfo } from '../types/MapDataTypes'
+
+jest.mock('@turf/boolean-point-in-polygon')
+import booleanPointInPolygon from '@turf/boolean-point-in-polygon'
 
 const mockUrl = 'https://things.com'
 const mockLayers: LayerInfo[] = [
@@ -61,6 +82,16 @@ const mockGeoFeatures = {
 } as unknown as MapGeoJSONFeature //allows for partial mock
 
 const makeMap = () => ({ setFeatureState: jest.fn(), getFeatureState: jest.fn() }) as unknown as Map
+
+const makeQueryMap = () =>
+  ({
+    querySourceFeatures: jest.fn().mockReturnValue([]),
+    isSourceLoaded: jest.fn().mockReturnValue(false),
+    on: jest.fn(),
+    off: jest.fn(),
+    setFeatureState: jest.fn(),
+    getFeatureState: jest.fn(),
+  }) as unknown as Map
 
 const makeEvent = (id?: string | number) => {
   const mockFeature = {
@@ -292,6 +323,496 @@ describe('map utilities', () => {
     it('uses transparent as the final fallback', () => {
       const result = buildSedExportWatershedExpression(2020)
       expect(result[result.length - 1]).toBe(transparent)
+    })
+  })
+
+  // ─── New test blocks ──────────────────────────────────────────────────────
+
+  describe('getUpdatedBenthicColor', () => {
+    it('returns atlasBenthicColors[layerId] when currentColors[layerId] is transparent', () => {
+      const currentColors = { coral_algae: transparent }
+      expect(getUpdatedBenthicColor('coral_algae', currentColors)).toBe(
+        atlasBenthicColors['coral_algae'],
+      )
+    })
+
+    it('returns transparent when currentColors[layerId] is not transparent', () => {
+      const currentColors = { coral_algae: '#CC6677' }
+      expect(getUpdatedBenthicColor('coral_algae', currentColors)).toBe(transparent)
+    })
+  })
+
+  describe('calculateFeatureBounds', () => {
+    it('returns the correct bounding box corners for a polygon feature', () => {
+      const feature = {
+        geometry: {
+          type: 'Polygon',
+          coordinates: [
+            [
+              [178.0, -17.0],
+              [179.0, -17.0],
+              [179.0, -18.0],
+              [178.0, -18.0],
+              [178.0, -17.0],
+            ],
+          ],
+        },
+      } as unknown as MapGeoJSONFeature
+
+      const bounds = calculateFeatureBounds(feature)
+      expect(bounds._sw.lng).toBeCloseTo(178.0)
+      expect(bounds._sw.lat).toBeCloseTo(-18.0)
+      expect(bounds._ne.lng).toBeCloseTo(179.0)
+      expect(bounds._ne.lat).toBeCloseTo(-17.0)
+    })
+  })
+
+  describe('clearPolygonHover', () => {
+    it('calls setFeatureState with hover: false and nullifies the ref when ref is set', () => {
+      const map = makeMap()
+      const hoveredRef = { current: 'some-id' } as RefObject<string | number | null>
+      clearPolygonHover(map, hoveredRef, mockLayers[1])
+      expect(map.setFeatureState).toHaveBeenCalledWith(
+        {
+          source: mockLayers[1].sourceId,
+          sourceLayer: mockLayers[1].sourceFileName,
+          id: 'some-id',
+        },
+        { hover: false },
+      )
+      expect(hoveredRef.current).toBeNull()
+    })
+
+    it('does nothing when ref is null', () => {
+      const map = makeMap()
+      const hoveredRef = { current: null } as RefObject<string | number | null>
+      clearPolygonHover(map, hoveredRef, mockLayers[1])
+      expect(map.setFeatureState).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('clearPolygonSelect', () => {
+    it('calls setFeatureState with select: false and nullifies the ref when ref is set', () => {
+      const map = makeMap()
+      const clickRef = { current: 'selected-id' } as RefObject<string | number | null>
+      clearPolygonSelect(map, clickRef, mockLayers[2])
+      expect(map.setFeatureState).toHaveBeenCalledWith(
+        {
+          source: mockLayers[2].sourceId,
+          sourceLayer: mockLayers[2].sourceFileName,
+          id: 'selected-id',
+        },
+        { select: false },
+      )
+      expect(clickRef.current).toBeNull()
+    })
+
+    it('does nothing when ref is null', () => {
+      const map = makeMap()
+      const clickRef = { current: null } as RefObject<string | number | null>
+      clearPolygonSelect(map, clickRef, mockLayers[2])
+      expect(map.setFeatureState).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('setPolygonSelect', () => {
+    it('sets clickRef.current to featureId and calls setFeatureState with select: true', () => {
+      const map = makeMap()
+      const clickRef = { current: null } as RefObject<string | number | null>
+      setPolygonSelect(map, clickRef, mockLayers[1], 'feature-99')
+      expect(clickRef.current).toBe('feature-99')
+      expect(map.setFeatureState).toHaveBeenCalledWith(
+        {
+          source: mockLayers[1].sourceId,
+          sourceLayer: mockLayers[1].sourceFileName,
+          id: 'feature-99',
+        },
+        { select: true },
+      )
+    })
+
+    it('overwrites an existing ref value with the new featureId', () => {
+      const map = makeMap()
+      const clickRef = { current: 'old-id' } as RefObject<string | number | null>
+      setPolygonSelect(map, clickRef, mockLayers[1], 'new-id')
+      expect(clickRef.current).toBe('new-id')
+    })
+  })
+
+  describe('mapToggleChange', () => {
+    const yearLayers: LayerInfo[] = [
+      { ...mockLayers[0], layerId: 'benthic', year: 2000, isLayerOn: false },
+      { ...mockLayers[0], layerId: 'benthic', year: 2005, isLayerOn: false },
+      { ...mockLayers[0], layerId: 'other', year: undefined, isLayerOn: false },
+    ]
+
+    it('updates isLayerOn only for the layer with the matching id and year', () => {
+      const result = mapToggleChange(yearLayers, 'benthic', true, 2000)
+      expect(result[0].isLayerOn).toBe(true)
+      expect(result[1].isLayerOn).toBe(false) // year 2005 ≠ 2000
+      expect(result[2].isLayerOn).toBe(false) // different layerId
+    })
+
+    it('updates isLayerOn for a layer with year === undefined regardless of the year argument', () => {
+      const result = mapToggleChange(yearLayers, 'other', true, 2020)
+      expect(result[0].isLayerOn).toBe(false)
+      expect(result[1].isLayerOn).toBe(false)
+      expect(result[2].isLayerOn).toBe(true)
+    })
+
+    it('leaves all layers unchanged when no layerId matches', () => {
+      const result = mapToggleChange(yearLayers, 'nonexistent', true, 2000)
+      expect(result.every((l) => !l.isLayerOn)).toBe(true)
+    })
+
+    it('returns a new array without mutating the original', () => {
+      const result = mapToggleChange(yearLayers, 'benthic', true, 2000)
+      expect(result).not.toBe(yearLayers)
+      expect(yearLayers[0].isLayerOn).toBe(false)
+    })
+  })
+
+  describe('buildBenthicFillExpression', () => {
+    const colors = {
+      coral_algae: '#CC6677',
+      microalgal_mats: '#44AA99',
+      rock: '#88CCEE',
+      rubble: '#332288',
+      sand: '#DECC77',
+      seagrass: '#117733',
+    }
+
+    it('starts with "case"', () => {
+      const expr = buildBenthicFillExpression(colors)
+      expect(expr[0]).toBe('case')
+    })
+
+    it('ends with the transparent fallback', () => {
+      const expr = buildBenthicFillExpression(colors)
+      expect(expr[expr.length - 1]).toBe(transparent)
+    })
+
+    it('maps each class_name condition to the correct colour', () => {
+      const expr = buildBenthicFillExpression(colors)
+
+      const coralIdx = (expr as unknown[]).findIndex(
+        (e) => Array.isArray(e) && (e as unknown[])[2] === 'Coral/Algae',
+      )
+      expect(coralIdx).toBeGreaterThan(-1)
+      expect(expr[coralIdx + 1]).toBe(colors['coral_algae'])
+
+      const sandIdx = (expr as unknown[]).findIndex(
+        (e) => Array.isArray(e) && (e as unknown[])[2] === 'Sand',
+      )
+      expect(sandIdx).toBeGreaterThan(-1)
+      expect(expr[sandIdx + 1]).toBe(colors['sand'])
+    })
+  })
+
+  describe('postZonalStats', () => {
+    it('returns parsed JSON on a successful response', async () => {
+      const mockData = { result: 'ok' }
+      jest.spyOn(global, 'fetch').mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockData),
+      } as Response)
+
+      const result = await postZonalStats({ aoi: null })
+      expect(result).toEqual(mockData)
+    })
+
+    it('throws when the response status is not ok', async () => {
+      jest.spyOn(global, 'fetch').mockResolvedValue({
+        ok: false,
+        status: 422,
+      } as Response)
+
+      await expect(postZonalStats({ aoi: null })).rejects.toThrow()
+    })
+
+    it('throws on a network-level error', async () => {
+      jest.spyOn(global, 'fetch').mockRejectedValue(new Error('Network failure'))
+
+      await expect(postZonalStats({ aoi: null })).rejects.toThrow()
+    })
+  })
+
+  describe('prepareZonalStatsCall', () => {
+    it('POSTs to BASE_ZONAL_STATS_API with the correct payload shape', async () => {
+      const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({}),
+      } as Response)
+
+      await prepareZonalStatsCall({ lng: 179.0, lat: -18.0 }, 2020)
+
+      const [url, options] = fetchSpy.mock.calls[0]
+      expect(url).toBe(BASE_ZONAL_STATS_API)
+
+      const body = JSON.parse(options!.body as string)
+      expect(body.aoi).toEqual({ type: 'Point', coordinates: [179.0, -18.0] })
+      expect(body.url).toBe(SEDIMENT_EXPOSURE_2020_URL)
+      expect(body.bands).toEqual([1, 2, 3, 4, 5, 6, 7])
+      expect(body.stats).toEqual(['majority'])
+    })
+
+    it('uses the correct COG URL for the requested year', async () => {
+      const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({}),
+      } as Response)
+
+      await prepareZonalStatsCall({ lng: 178.0, lat: -17.0 }, 2000)
+
+      const [, options] = fetchSpy.mock.calls[0]
+      const body = JSON.parse(options!.body as string)
+      expect(body.url).toBe(SEDIMENT_EXPOSURE_2000_URL)
+    })
+  })
+
+  describe('getAllYearZonalStats', () => {
+    it('calls for all 5 years and merges their results', async () => {
+      jest.spyOn(global, 'fetch').mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ band_1: { majority: 3 } }),
+      } as Response)
+
+      const result = await getAllYearZonalStats({ lng: 179.0, lat: -18.0 })
+
+      expect(fetch).toHaveBeenCalledTimes(5)
+      expect(result).toHaveProperty('2000')
+      expect(result).toHaveProperty('2005')
+      expect(result).toHaveProperty('2010')
+      expect(result).toHaveProperty('2015')
+      expect(result).toHaveProperty('2020')
+    })
+
+    it('returns an empty object for a failing year without throwing', async () => {
+      jest
+        .spyOn(global, 'fetch')
+        .mockRejectedValueOnce(new Error('Network failure')) // year 2000 fails
+        .mockResolvedValue({
+          ok: true,
+          json: () => Promise.resolve({ band_1: { majority: 1 } }),
+        } as Response)
+
+      const result = await getAllYearZonalStats({ lng: 179.0, lat: -18.0 })
+
+      expect(result[2000]).toEqual({})
+      expect(result[2005]).toEqual({ band_1: { majority: 1 } })
+    })
+  })
+
+  describe('resolveBasemapBeforeId', () => {
+    it('returns the first symbol layer after the last blocking layer', () => {
+      const layers = [
+        { id: 'fill-layer', type: 'fill' },
+        { id: 'label-before-blocking', type: 'symbol' },
+        { id: 'hillshade-layer', type: 'hillshade' },
+        { id: 'label-after-blocking', type: 'symbol' },
+      ]
+      expect(resolveBasemapBeforeId(layers)).toBe('label-after-blocking')
+    })
+
+    it('falls back to the first symbol when there are no blocking layers', () => {
+      const layers = [
+        { id: 'first-symbol', type: 'symbol' },
+        { id: 'line-layer', type: 'line' },
+        { id: 'second-symbol', type: 'symbol' },
+      ]
+      expect(resolveBasemapBeforeId(layers)).toBe('first-symbol')
+    })
+
+    it('returns the first non-background layer when there are no symbol layers at all', () => {
+      const layers = [
+        { id: 'bg', type: 'background' },
+        { id: 'road', type: 'line' },
+        { id: 'border', type: 'line' },
+      ]
+      expect(resolveBasemapBeforeId(layers)).toBe('road')
+    })
+
+    it('returns undefined when the layers array is empty', () => {
+      expect(resolveBasemapBeforeId([])).toBeUndefined()
+    })
+  })
+
+  describe('querySourceFeatureWhenReady', () => {
+    afterEach(() => {
+      jest.useRealTimers()
+    })
+
+    it('calls onResult synchronously and returns a no-op cancel when a feature is found immediately', () => {
+      const mockFeature = {
+        id: 'f1',
+        geometry: { type: 'Polygon' },
+      } as unknown as MapGeoJSONFeature
+      const map = makeQueryMap()
+      ;(map.querySourceFeatures as jest.Mock).mockReturnValue([mockFeature])
+      const onResult = jest.fn()
+
+      const cancel = querySourceFeatureWhenReady(
+        map,
+        'src',
+        'layer',
+        [] as unknown as FilterSpecification,
+        onResult,
+      )
+
+      expect(onResult).toHaveBeenCalledWith(mockFeature)
+      expect(map.on).not.toHaveBeenCalled()
+
+      cancel() // no-op — should not call onResult a second time
+      expect(onResult).toHaveBeenCalledTimes(1)
+    })
+
+    it('registers a sourcedata listener when no feature is found immediately', () => {
+      const map = makeQueryMap()
+      const onResult = jest.fn()
+
+      querySourceFeatureWhenReady(
+        map,
+        'src',
+        'layer',
+        [] as unknown as FilterSpecification,
+        onResult,
+        10_000,
+      )
+
+      expect(onResult).not.toHaveBeenCalled()
+      expect(map.on).toHaveBeenCalledWith('sourcedata', expect.any(Function))
+    })
+
+    it('calls onResult with the feature once the sourcedata event fires', () => {
+      const mockFeature = {
+        id: 'f2',
+        geometry: { type: 'Polygon' },
+      } as unknown as MapGeoJSONFeature
+      const map = makeQueryMap()
+      ;(map.querySourceFeatures as jest.Mock)
+        .mockReturnValueOnce([]) // no feature on first try
+        .mockReturnValue([mockFeature])
+      const onResult = jest.fn()
+
+      querySourceFeatureWhenReady(
+        map,
+        'src',
+        'layer',
+        [] as unknown as FilterSpecification,
+        onResult,
+        10_000,
+      )
+
+      const sourcedataHandler = (map.on as jest.Mock).mock.calls.find(
+        (c) => c[0] === 'sourcedata',
+      )[1]
+      sourcedataHandler({ sourceId: 'src' })
+
+      expect(onResult).toHaveBeenCalledWith(mockFeature)
+      expect(map.off).toHaveBeenCalledWith('sourcedata', sourcedataHandler)
+    })
+
+    it('calls onResult(null) and cleans up when cancel is invoked', () => {
+      const map = makeQueryMap()
+      const onResult = jest.fn()
+
+      const cancel = querySourceFeatureWhenReady(
+        map,
+        'src',
+        'layer',
+        [] as unknown as FilterSpecification,
+        onResult,
+        10_000,
+      )
+
+      cancel()
+
+      expect(onResult).toHaveBeenCalledWith(null)
+      expect(map.off).toHaveBeenCalled()
+    })
+
+    it('calls onResult(null) after the timeout elapses', () => {
+      jest.useFakeTimers()
+      const map = makeQueryMap()
+      const onResult = jest.fn()
+
+      querySourceFeatureWhenReady(
+        map,
+        'src',
+        'layer',
+        [] as unknown as FilterSpecification,
+        onResult,
+        5_000,
+      )
+
+      expect(onResult).not.toHaveBeenCalled()
+      jest.advanceTimersByTime(5_000)
+      expect(onResult).toHaveBeenCalledWith(null)
+    })
+  })
+
+  describe('querySourceFeatureAtPointWhenReady', () => {
+    const point = { lng: 179.0, lat: -18.0 }
+
+    beforeEach(() => {
+      ;(booleanPointInPolygon as jest.Mock).mockReturnValue(false)
+    })
+
+    afterEach(() => {
+      jest.useRealTimers()
+    })
+
+    it('calls onResult synchronously with the matching feature when a polygon contains the point', () => {
+      const mockFeature = {
+        id: 'poly-1',
+        geometry: { type: 'Polygon' },
+      } as unknown as MapGeoJSONFeature
+      const map = makeQueryMap()
+      ;(map.querySourceFeatures as jest.Mock).mockReturnValue([mockFeature])
+      ;(booleanPointInPolygon as jest.Mock).mockReturnValue(true)
+      const onResult = jest.fn()
+
+      querySourceFeatureAtPointWhenReady(map, 'src', 'layer', point, onResult)
+
+      expect(onResult).toHaveBeenCalledWith(mockFeature)
+      expect(map.on).not.toHaveBeenCalled()
+    })
+
+    it('calls onResult(null) synchronously when the source is already loaded but contains no match', () => {
+      const map = makeQueryMap()
+      ;(map.querySourceFeatures as jest.Mock).mockReturnValue([])
+      ;(map.isSourceLoaded as jest.Mock).mockReturnValue(true)
+      const onResult = jest.fn()
+
+      querySourceFeatureAtPointWhenReady(map, 'src', 'layer', point, onResult)
+
+      expect(onResult).toHaveBeenCalledWith(null)
+      expect(map.on).not.toHaveBeenCalled()
+    })
+
+    it('calls onResult(null) when cancel is invoked before tiles finish loading', () => {
+      const map = makeQueryMap()
+      ;(map.isSourceLoaded as jest.Mock).mockReturnValue(false)
+      const onResult = jest.fn()
+
+      const cancel = querySourceFeatureAtPointWhenReady(map, 'src', 'layer', point, onResult)
+      cancel()
+
+      expect(onResult).toHaveBeenCalledWith(null)
+      expect(map.off).toHaveBeenCalled()
+    })
+
+    it('calls onResult(null) after the timeout elapses with no matching feature', () => {
+      jest.useFakeTimers()
+      const map = makeQueryMap()
+      ;(map.isSourceLoaded as jest.Mock).mockReturnValue(false)
+      const onResult = jest.fn()
+
+      querySourceFeatureAtPointWhenReady(map, 'src', 'layer', point, onResult, 3_000)
+
+      expect(onResult).not.toHaveBeenCalled()
+      jest.advanceTimersByTime(3_000)
+      expect(onResult).toHaveBeenCalledWith(null)
     })
   })
 })

--- a/src/tests/mapUtils.test.ts
+++ b/src/tests/mapUtils.test.ts
@@ -367,56 +367,42 @@ describe('map utilities', () => {
     })
   })
 
-  describe('clearPolygonHover', () => {
-    it('calls setFeatureState with hover: false and nullifies the ref when ref is set', () => {
+  describe('polygon state helpers', () => {
+    it('clearPolygonHover and clearPolygonSelect call setFeatureState with the correct state and null the ref', () => {
       const map = makeMap()
-      const hoveredRef = { current: 'some-id' } as RefObject<string | number | null>
+      const hoveredRef = { current: 'hover-id' } as RefObject<string | number | null>
       clearPolygonHover(map, hoveredRef, mockLayers[1])
       expect(map.setFeatureState).toHaveBeenCalledWith(
         {
           source: mockLayers[1].sourceId,
           sourceLayer: mockLayers[1].sourceFileName,
-          id: 'some-id',
+          id: 'hover-id',
         },
         { hover: false },
       )
       expect(hoveredRef.current).toBeNull()
-    })
 
-    it('does nothing when ref is null', () => {
-      const map = makeMap()
-      const hoveredRef = { current: null } as RefObject<string | number | null>
-      clearPolygonHover(map, hoveredRef, mockLayers[1])
-      expect(map.setFeatureState).not.toHaveBeenCalled()
-    })
-  })
-
-  describe('clearPolygonSelect', () => {
-    it('calls setFeatureState with select: false and nullifies the ref when ref is set', () => {
-      const map = makeMap()
-      const clickRef = { current: 'selected-id' } as RefObject<string | number | null>
+      const clickRef = { current: 'select-id' } as RefObject<string | number | null>
       clearPolygonSelect(map, clickRef, mockLayers[2])
       expect(map.setFeatureState).toHaveBeenCalledWith(
         {
           source: mockLayers[2].sourceId,
           sourceLayer: mockLayers[2].sourceFileName,
-          id: 'selected-id',
+          id: 'select-id',
         },
         { select: false },
       )
       expect(clickRef.current).toBeNull()
     })
 
-    it('does nothing when ref is null', () => {
+    it('clear helpers do nothing when ref is null', () => {
       const map = makeMap()
-      const clickRef = { current: null } as RefObject<string | number | null>
-      clearPolygonSelect(map, clickRef, mockLayers[2])
+      clearPolygonHover(map, { current: null } as RefObject<string | number | null>, mockLayers[1])
+      clearPolygonSelect(map, { current: null } as RefObject<string | number | null>, mockLayers[2])
       expect(map.setFeatureState).not.toHaveBeenCalled()
     })
-  })
 
-  describe('setPolygonSelect', () => {
-    it('sets clickRef.current to featureId and calls setFeatureState with select: true', () => {
+    it('setPolygonSelect updates the ref and calls setFeatureState with select: true', () => {
       const map = makeMap()
       const clickRef = { current: null } as RefObject<string | number | null>
       setPolygonSelect(map, clickRef, mockLayers[1], 'feature-99')
@@ -429,13 +415,6 @@ describe('map utilities', () => {
         },
         { select: true },
       )
-    })
-
-    it('overwrites an existing ref value with the new featureId', () => {
-      const map = makeMap()
-      const clickRef = { current: 'old-id' } as RefObject<string | number | null>
-      setPolygonSelect(map, clickRef, mockLayers[1], 'new-id')
-      expect(clickRef.current).toBe('new-id')
     })
   })
 

--- a/src/tests/routeUtils.test.ts
+++ b/src/tests/routeUtils.test.ts
@@ -66,32 +66,19 @@ describe('route parameter utilities', () => {
   })
 
   describe('getValidYear', () => {
-    it('returns defaultYear (2020) for null input', () => {
-      expect(getValidYear(null)).toBe(2020)
-    })
+    it.each([null, 'not-a-year', '1999', '2025'] as const)(
+      'returns defaultYear (2020) for invalid input (%s)',
+      (input) => {
+        expect(getValidYear(input)).toBe(2020)
+      },
+    )
 
-    it('returns defaultYear for non-numeric string', () => {
-      expect(getValidYear('not-a-year')).toBe(2020)
-    })
-
-    it('returns defaultYear for a number not in availableYears', () => {
-      expect(getValidYear('1999')).toBe(2020)
-    })
-
-    it('returns defaultYear for a number outside the available range', () => {
-      expect(getValidYear('2025')).toBe(2020)
-    })
-
-    it('returns parsed year when it is in availableYears', () => {
-      expect(getValidYear('2020')).toBe(2020)
-    })
-
-    it('returns parsed year for each available year', () => {
-      expect(getValidYear('2015')).toBe(2015)
-      expect(getValidYear('2010')).toBe(2010)
-      expect(getValidYear('2005')).toBe(2005)
-      expect(getValidYear('2000')).toBe(2000)
-    })
+    it.each(['2020', '2015', '2010', '2005', '2000'] as const)(
+      'returns parsed year for each available year (%s)',
+      (year) => {
+        expect(getValidYear(year)).toBe(Number(year))
+      },
+    )
   })
 
   describe('getValidLayers', () => {
@@ -163,105 +150,49 @@ describe('route parameter utilities', () => {
   })
 
   describe('getValidLatLng', () => {
-    it('returns { lat: null, lng: null } when both are null', () => {
-      expect(getValidLatLng(null, null)).toEqual({ lat: null, lng: null })
+    it.each([
+      [null, null],
+      [null, '100'],
+      ['45', null],
+      ['not-a-number', '100'],
+      ['45', 'not-a-number'],
+      ['-91', '100'],
+      ['91', '100'],
+      ['45', '-181'],
+      ['45', '181'],
+    ] as const)('returns null/null for invalid input (%s, %s)', (lat, lng) => {
+      expect(getValidLatLng(lat, lng)).toEqual({ lat: null, lng: null })
     })
 
-    it('returns { lat: null, lng: null } when lat is null', () => {
-      expect(getValidLatLng(null, '100')).toEqual({ lat: null, lng: null })
-    })
-
-    it('returns { lat: null, lng: null } when lng is null', () => {
-      expect(getValidLatLng('45', null)).toEqual({ lat: null, lng: null })
-    })
-
-    it('returns { lat: null, lng: null } when lat is NaN', () => {
-      expect(getValidLatLng('not-a-number', '100')).toEqual({ lat: null, lng: null })
-    })
-
-    it('returns { lat: null, lng: null } when lng is NaN', () => {
-      expect(getValidLatLng('45', 'not-a-number')).toEqual({ lat: null, lng: null })
-    })
-
-    it('returns { lat: null, lng: null } when lat is below -90', () => {
-      expect(getValidLatLng('-91', '100')).toEqual({ lat: null, lng: null })
-    })
-
-    it('returns { lat: null, lng: null } when lat is above 90', () => {
-      expect(getValidLatLng('91', '100')).toEqual({ lat: null, lng: null })
-    })
-
-    it('returns { lat: null, lng: null } when lng is below -180', () => {
-      expect(getValidLatLng('45', '-181')).toEqual({ lat: null, lng: null })
-    })
-
-    it('returns { lat: null, lng: null } when lng is above 180', () => {
-      expect(getValidLatLng('45', '181')).toEqual({ lat: null, lng: null })
-    })
-
-    it('returns parsed floats when both lat and lng are valid', () => {
-      expect(getValidLatLng('45.5', '100.25')).toEqual({ lat: 45.5, lng: 100.25 })
-    })
-
-    it('accepts boundary lat values (-90 and 90)', () => {
-      expect(getValidLatLng('-90', '0')).toEqual({ lat: -90, lng: 0 })
-      expect(getValidLatLng('90', '0')).toEqual({ lat: 90, lng: 0 })
-    })
-
-    it('accepts boundary lng values (-180 and 180)', () => {
-      expect(getValidLatLng('0', '-180')).toEqual({ lat: 0, lng: -180 })
-      expect(getValidLatLng('0', '180')).toEqual({ lat: 0, lng: 180 })
-    })
-
-    it('accepts negative valid coordinates', () => {
-      expect(getValidLatLng('-17.5', '-178.5')).toEqual({ lat: -17.5, lng: -178.5 })
-    })
+    it.each([
+      ['45.5', '100.25', 45.5, 100.25],
+      ['-90', '0', -90, 0],
+      ['90', '0', 90, 0],
+      ['0', '-180', 0, -180],
+      ['0', '180', 0, 180],
+      ['-17.5', '-178.5', -17.5, -178.5],
+    ] as const)(
+      'returns parsed floats for valid input (%s, %s)',
+      (lat, lng, expectedLat, expectedLng) => {
+        expect(getValidLatLng(lat, lng)).toEqual({ lat: expectedLat, lng: expectedLng })
+      },
+    )
   })
 
   describe('getValidDispersalPoint', () => {
-    it('returns null for null input', () => {
-      expect(getValidDispersalPoint(null)).toBeNull()
+    it.each([null, '', '   '] as const)('returns null for falsy input (%s)', (input) => {
+      expect(getValidDispersalPoint(input)).toBeNull()
     })
 
-    it('returns null for empty string', () => {
-      expect(getValidDispersalPoint('')).toBeNull()
-    })
+    it.each(['45', '45,100,200'] as const)(
+      'returns null for wrong number of parts (%s)',
+      (input) => {
+        expect(getValidDispersalPoint(input)).toBeNull()
+      },
+    )
 
-    it('returns null if not two comma-separated values', () => {
-      expect(getValidDispersalPoint('45')).toBeNull()
-    })
-
-    it('returns null for more than two comma-separated values', () => {
-      expect(getValidDispersalPoint('45,100,200')).toBeNull()
-    })
-
-    it('returns null if lat is invalid', () => {
-      expect(getValidDispersalPoint('not-a-number,100')).toBeNull()
-    })
-
-    it('returns null if lng is invalid', () => {
-      expect(getValidDispersalPoint('45,not-a-number')).toBeNull()
-    })
-
-    it('returns null if lat is out of range', () => {
-      expect(getValidDispersalPoint('91,100')).toBeNull()
-    })
-
-    it('returns null if lng is out of range', () => {
-      expect(getValidDispersalPoint('45,181')).toBeNull()
-    })
-
-    it('returns { lat, lng } for valid "lat,lng" input', () => {
+    it('returns { lat, lng } for a valid comma-separated pair', () => {
       expect(getValidDispersalPoint('45.5,100.25')).toEqual({ lat: 45.5, lng: 100.25 })
-    })
-
-    it('returns { lat, lng } for negative valid coordinates', () => {
-      expect(getValidDispersalPoint('-17.5,-178.5')).toEqual({ lat: -17.5, lng: -178.5 })
-    })
-
-    it('returns { lat, lng } for boundary coordinate values', () => {
-      expect(getValidDispersalPoint('90,180')).toEqual({ lat: 90, lng: 180 })
-      expect(getValidDispersalPoint('-90,-180')).toEqual({ lat: -90, lng: -180 })
     })
   })
 })

--- a/src/tests/routeUtils.test.ts
+++ b/src/tests/routeUtils.test.ts
@@ -1,0 +1,267 @@
+import {
+  getValidRegion,
+  getValidWatershed,
+  getValidYear,
+  getValidLayers,
+  getValidZoom,
+  getValidLatLng,
+  getValidDispersalPoint,
+} from '../utils/routeUtils'
+
+jest.mock('../data/mapData', () => ({
+  availableYears: [2020, 2015, 2010, 2005, 2000],
+  defaultYear: 2020,
+  defaultLayersToShow: ['sed_export', 'sed_dispersal', 'plumes'],
+  urlControlledLayerIds: ['none', 'sed_export', 'lulc', 'sed_dispersal', 'plumes'],
+}))
+
+jest.mock('../data/regionData', () => ({
+  defaultGlobalRegionOption: { id: 'global', regionType: 'global', label: 'Global' },
+  regionOptions: [
+    { id: 'global', regionType: 'global', label: 'Global' },
+    { id: 'fiji', regionType: 'country', label: 'Fiji' },
+    { id: 'solomon-islands', regionType: 'country', label: 'Solomon Islands' },
+  ],
+}))
+
+describe('route parameter utilities', () => {
+  describe('getValidRegion', () => {
+    it('returns defaultGlobalRegionOption when param is null', () => {
+      expect(getValidRegion(null)).toEqual({ id: 'global', regionType: 'global', label: 'Global' })
+    })
+
+    it('returns defaultGlobalRegionOption when param does not match any region id', () => {
+      expect(getValidRegion('unknown-region')).toEqual({
+        id: 'global',
+        regionType: 'global',
+        label: 'Global',
+      })
+    })
+
+    it('returns matched regionOption when id matches', () => {
+      expect(getValidRegion('fiji')).toEqual({ id: 'fiji', regionType: 'country', label: 'Fiji' })
+    })
+
+    it('returns defaultGlobalRegionOption for empty string', () => {
+      expect(getValidRegion('')).toEqual({ id: 'global', regionType: 'global', label: 'Global' })
+    })
+  })
+
+  describe('getValidWatershed', () => {
+    it('returns null for null input', () => {
+      expect(getValidWatershed(null)).toBeNull()
+    })
+
+    it('returns null for empty string', () => {
+      expect(getValidWatershed('')).toBeNull()
+    })
+
+    it('returns null for whitespace-only string', () => {
+      expect(getValidWatershed('   ')).toBeNull()
+    })
+
+    it('trims leading and trailing whitespace from valid input', () => {
+      expect(getValidWatershed('  watershed-123  ')).toBe('watershed-123')
+    })
+  })
+
+  describe('getValidYear', () => {
+    it('returns defaultYear (2020) for null input', () => {
+      expect(getValidYear(null)).toBe(2020)
+    })
+
+    it('returns defaultYear for non-numeric string', () => {
+      expect(getValidYear('not-a-year')).toBe(2020)
+    })
+
+    it('returns defaultYear for a number not in availableYears', () => {
+      expect(getValidYear('1999')).toBe(2020)
+    })
+
+    it('returns defaultYear for a number outside the available range', () => {
+      expect(getValidYear('2025')).toBe(2020)
+    })
+
+    it('returns parsed year when it is in availableYears', () => {
+      expect(getValidYear('2020')).toBe(2020)
+    })
+
+    it('returns parsed year for each available year', () => {
+      expect(getValidYear('2015')).toBe(2015)
+      expect(getValidYear('2010')).toBe(2010)
+      expect(getValidYear('2005')).toBe(2005)
+      expect(getValidYear('2000')).toBe(2000)
+    })
+  })
+
+  describe('getValidLayers', () => {
+    it('returns defaultLayersToShow for null input', () => {
+      expect(getValidLayers(null)).toEqual(['sed_export', 'sed_dispersal', 'plumes'])
+    })
+
+    it('returns empty array for "none"', () => {
+      expect(getValidLayers('none')).toEqual([])
+    })
+
+    it('returns parsed layer array for valid comma-separated known layer ids', () => {
+      expect(getValidLayers('sed_export,lulc')).toEqual(['sed_export', 'lulc'])
+    })
+
+    it('returns a single valid layer', () => {
+      expect(getValidLayers('plumes')).toEqual(['plumes'])
+    })
+
+    it('returns defaultLayersToShow if any layer id is unknown', () => {
+      expect(getValidLayers('sed_export,unknown_layer')).toEqual([
+        'sed_export',
+        'sed_dispersal',
+        'plumes',
+      ])
+    })
+
+    it('returns defaultLayersToShow for empty string', () => {
+      expect(getValidLayers('')).toEqual(['sed_export', 'sed_dispersal', 'plumes'])
+    })
+
+    it('returns defaultLayersToShow if all layer ids are unknown', () => {
+      expect(getValidLayers('foo,bar')).toEqual(['sed_export', 'sed_dispersal', 'plumes'])
+    })
+  })
+
+  describe('getValidZoom', () => {
+    it('returns null for null input', () => {
+      expect(getValidZoom(null)).toBeNull()
+    })
+
+    it('returns null for non-numeric string', () => {
+      expect(getValidZoom('not-a-zoom')).toBeNull()
+    })
+
+    it('returns null for zoom below 0', () => {
+      expect(getValidZoom('-1')).toBeNull()
+    })
+
+    it('returns null for zoom above 24', () => {
+      expect(getValidZoom('25')).toBeNull()
+    })
+
+    it('returns parsed float for minimum valid zoom (0)', () => {
+      expect(getValidZoom('0')).toBe(0)
+    })
+
+    it('returns parsed float for maximum valid zoom (24)', () => {
+      expect(getValidZoom('24')).toBe(24)
+    })
+
+    it('returns parsed float for a mid-range zoom value', () => {
+      expect(getValidZoom('10.5')).toBe(10.5)
+    })
+
+    it('returns null for empty string', () => {
+      expect(getValidZoom('')).toBeNull()
+    })
+  })
+
+  describe('getValidLatLng', () => {
+    it('returns { lat: null, lng: null } when both are null', () => {
+      expect(getValidLatLng(null, null)).toEqual({ lat: null, lng: null })
+    })
+
+    it('returns { lat: null, lng: null } when lat is null', () => {
+      expect(getValidLatLng(null, '100')).toEqual({ lat: null, lng: null })
+    })
+
+    it('returns { lat: null, lng: null } when lng is null', () => {
+      expect(getValidLatLng('45', null)).toEqual({ lat: null, lng: null })
+    })
+
+    it('returns { lat: null, lng: null } when lat is NaN', () => {
+      expect(getValidLatLng('not-a-number', '100')).toEqual({ lat: null, lng: null })
+    })
+
+    it('returns { lat: null, lng: null } when lng is NaN', () => {
+      expect(getValidLatLng('45', 'not-a-number')).toEqual({ lat: null, lng: null })
+    })
+
+    it('returns { lat: null, lng: null } when lat is below -90', () => {
+      expect(getValidLatLng('-91', '100')).toEqual({ lat: null, lng: null })
+    })
+
+    it('returns { lat: null, lng: null } when lat is above 90', () => {
+      expect(getValidLatLng('91', '100')).toEqual({ lat: null, lng: null })
+    })
+
+    it('returns { lat: null, lng: null } when lng is below -180', () => {
+      expect(getValidLatLng('45', '-181')).toEqual({ lat: null, lng: null })
+    })
+
+    it('returns { lat: null, lng: null } when lng is above 180', () => {
+      expect(getValidLatLng('45', '181')).toEqual({ lat: null, lng: null })
+    })
+
+    it('returns parsed floats when both lat and lng are valid', () => {
+      expect(getValidLatLng('45.5', '100.25')).toEqual({ lat: 45.5, lng: 100.25 })
+    })
+
+    it('accepts boundary lat values (-90 and 90)', () => {
+      expect(getValidLatLng('-90', '0')).toEqual({ lat: -90, lng: 0 })
+      expect(getValidLatLng('90', '0')).toEqual({ lat: 90, lng: 0 })
+    })
+
+    it('accepts boundary lng values (-180 and 180)', () => {
+      expect(getValidLatLng('0', '-180')).toEqual({ lat: 0, lng: -180 })
+      expect(getValidLatLng('0', '180')).toEqual({ lat: 0, lng: 180 })
+    })
+
+    it('accepts negative valid coordinates', () => {
+      expect(getValidLatLng('-17.5', '-178.5')).toEqual({ lat: -17.5, lng: -178.5 })
+    })
+  })
+
+  describe('getValidDispersalPoint', () => {
+    it('returns null for null input', () => {
+      expect(getValidDispersalPoint(null)).toBeNull()
+    })
+
+    it('returns null for empty string', () => {
+      expect(getValidDispersalPoint('')).toBeNull()
+    })
+
+    it('returns null if not two comma-separated values', () => {
+      expect(getValidDispersalPoint('45')).toBeNull()
+    })
+
+    it('returns null for more than two comma-separated values', () => {
+      expect(getValidDispersalPoint('45,100,200')).toBeNull()
+    })
+
+    it('returns null if lat is invalid', () => {
+      expect(getValidDispersalPoint('not-a-number,100')).toBeNull()
+    })
+
+    it('returns null if lng is invalid', () => {
+      expect(getValidDispersalPoint('45,not-a-number')).toBeNull()
+    })
+
+    it('returns null if lat is out of range', () => {
+      expect(getValidDispersalPoint('91,100')).toBeNull()
+    })
+
+    it('returns null if lng is out of range', () => {
+      expect(getValidDispersalPoint('45,181')).toBeNull()
+    })
+
+    it('returns { lat, lng } for valid "lat,lng" input', () => {
+      expect(getValidDispersalPoint('45.5,100.25')).toEqual({ lat: 45.5, lng: 100.25 })
+    })
+
+    it('returns { lat, lng } for negative valid coordinates', () => {
+      expect(getValidDispersalPoint('-17.5,-178.5')).toEqual({ lat: -17.5, lng: -178.5 })
+    })
+
+    it('returns { lat, lng } for boundary coordinate values', () => {
+      expect(getValidDispersalPoint('90,180')).toEqual({ lat: 90, lng: 180 })
+      expect(getValidDispersalPoint('-90,-180')).toEqual({ lat: -90, lng: -180 })
+    })
+  })
+})

--- a/src/utils/mapUtils.ts
+++ b/src/utils/mapUtils.ts
@@ -27,7 +27,7 @@ export function getActiveLayers(mapLayers: LayerInfo[]): string[] {
   return mapLayers.filter((layer) => layer.isLayerOn).map((layer) => layer.layerId)
 }
 
-export const getUpdatedBenthicColor = (layerId, currentColors) => {
+export const getUpdatedBenthicColor = (layerId: string, currentColors: Record<string, string>) => {
   if (currentColors[layerId] === transparent) {
     return atlasBenthicColors[layerId]
   } else {
@@ -426,7 +426,6 @@ export async function postZonalStats(payload) {
 
 export async function prepareZonalStatsCall(lngLat, year) {
   const { lat, lng } = lngLat
-  //todo: check if selected year has available exposure url
   const exposureUrls = {
     2000: SEDIMENT_EXPOSURE_2000_URL,
     2005: SEDIMENT_EXPOSURE_2005_URL,
@@ -437,7 +436,7 @@ export async function prepareZonalStatsCall(lngLat, year) {
 
   const basePayload = {
     aoi: { type: 'Point', coordinates: [lng, lat] },
-    url: exposureUrls[year], //todo: use year as parameter
+    url: exposureUrls[year],
     bands: [1, 2, 3, 4, 5, 6, 7],
     stats: ['majority'],
   }

--- a/src/utils/mapUtils.ts
+++ b/src/utils/mapUtils.ts
@@ -426,7 +426,7 @@ export async function postZonalStats(payload) {
 
 export async function prepareZonalStatsCall(lngLat, year) {
   const { lat, lng } = lngLat
-  const exposureUrls = {
+  const exposureUrls: Record<number, string> = {
     2000: SEDIMENT_EXPOSURE_2000_URL,
     2005: SEDIMENT_EXPOSURE_2005_URL,
     2010: SEDIMENT_EXPOSURE_2010_URL,
@@ -434,9 +434,14 @@ export async function prepareZonalStatsCall(lngLat, year) {
     2020: SEDIMENT_EXPOSURE_2020_URL,
   }
 
+  const resolvedUrl = exposureUrls[year]
+  if (!resolvedUrl) {
+    throw new Error(`No sediment exposure URL available for year: ${year}`)
+  }
+
   const basePayload = {
     aoi: { type: 'Point', coordinates: [lng, lat] },
-    url: exposureUrls[year],
+    url: resolvedUrl,
     bands: [1, 2, 3, 4, 5, 6, 7],
     stats: ['majority'],
   }


### PR DESCRIPTION
- Add unit tests for routeUtils
- Expand tests for mapUtils and chartUtils

## Every PR

Before merging, the developer of this pull request has checked the following:

- [x] Changes have been tested locally without errors
- [x] Lint has run and any errors have been resolved
- [x] Prettier has run on any changed files
- [x] Storybook stories have run and any errors have been resolved
- [x] Pre-existing unit tests have run and passed
  - [x] Unit tests have been added or updated, where possible, to prevent future regressions

## Post-Merge

- [ ] Code has merged and build success is confirmed in 'Actions'
- [ ] The corresponding Trello ticket has moved to the appropriate list (likely User-QA)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive unit test coverage for chart utility functions including region labeling, chart data generation, and plume data mapping.
  * Expanded map utility tests covering benthic styling, geometric bounds, map interaction management, zonal statistics, and feature querying.
  * Introduced new test suite for route parameter validation and normalization.

* **Chores**
  * Enhanced TypeScript type safety in map utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->