### PR TITLE
feat: [C218]: Remove sediment load unit conversion in chart data mapping

### DIFF
--- a/src/utils/chartUtils.ts
+++ b/src/utils/chartUtils.ts
@@ -251,10 +251,7 @@ export const mapChartConfigToData = (
     chartSeriesData.push({
       type: 'bar',
       x: sortedYears,
-      y:
-        chartName === 'sediment_load_historical'
-          ? sortedYears.map((year) => yearData[year] / 1000000)
-          : sortedYears.map((year) => yearData[year]),
+      y: sortedYears.map((year) => yearData[year]),
       name: i18next.t(prefixedTrace),
       marker: {
         color: chartProperties.legendColors[category],


### PR DESCRIPTION
## Every PR

Before merging, the developer of this pull request has checked the following:

- [x] Changes have been tested locally without errors
- [x] Lint has run and any errors have been resolved
- [x] Prettier has run on any changed files
- [x] Storybook stories have run and any errors have been resolved
- [x] Pre-existing unit tests have run and passed
  - [ ] Unit tests have been added or updated, where possible, to prevent future regressions

## Post-Merge

- [ ] Code has merged and build success is confirmed in 'Actions'
- [ ] The corresponding Trello ticket has moved to the appropriate list (likely User-QA)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted sediment load data display values to reflect actual measurements without applying previous scaling adjustments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/data-mermaid/clean-reefs-ui/pull/114?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->