### PR TITLE
fix: [C226] Update display scaling to always match the most recent data range regardless of year displayed.

### DIFF
--- a/src/components/BaseMap/BaseMap.tsx
+++ b/src/components/BaseMap/BaseMap.tsx
@@ -898,7 +898,13 @@ export default function BaseMap({
       }
 
       clearPolygonFeatureState(map, plumeLinkedHoverRef, currentPlumeLayer, 'linkedHover')
-      setPolygonFeatureState(map, plumeLinkedHoverRef, currentPlumeLayer, hoveredWatershedId, 'linkedHover')
+      setPolygonFeatureState(
+        map,
+        plumeLinkedHoverRef,
+        currentPlumeLayer,
+        hoveredWatershedId,
+        'linkedHover',
+      )
     }
     const onWatershedClick = (e: MapLayerMouseEvent) => {
       polygonClickHandler(map, e, watershedLayer)

--- a/src/components/MapContainer/MapContainer.tsx
+++ b/src/components/MapContainer/MapContainer.tsx
@@ -98,7 +98,7 @@ export default function MapContainer() {
     minValue: sedDispersalMinValue,
     maxValue: sedDispersalMaxValue,
     isLoading: sedDispersalLoading,
-  } = useRasterStatistics(SED_DISPERSAL_COLLECTION_ID, selectedRegion, selectedYear)
+  } = useRasterStatistics(SED_DISPERSAL_COLLECTION_ID, selectedRegion)
 
   // Update the active sed_dispersal tile URL when min/max values change; clear link when stats are unavailable
   useEffect(() => {

--- a/src/components/MapContainer/MapContainer.tsx
+++ b/src/components/MapContainer/MapContainer.tsx
@@ -42,10 +42,10 @@ export default function MapContainer() {
 
   const [searchParams, setSearchParams] = useSearchParams()
 
-  const { availableYears, defaultYear, isLoading: yearsLoading } = useAvailableYears()
+  const { availableYears, latestYear, isLoading: yearsLoading } = useAvailableYears()
 
   const year = searchParams.get('year')
-  const selectedYear = getValidYear(year, availableYears, defaultYear)
+  const selectedYear = getValidYear(year, availableYears, latestYear)
   const normalizedYearParam = selectedYear.toString()
   const shouldSyncYearParam = year !== normalizedYearParam
 
@@ -101,7 +101,7 @@ export default function MapContainer() {
     minValue: sedDispersalMinValue,
     maxValue: sedDispersalMaxValue,
     isLoading: sedDispersalLoading,
-  } = useRasterStatistics(SED_DISPERSAL_COLLECTION_ID, selectedRegion)
+  } = useRasterStatistics(SED_DISPERSAL_COLLECTION_ID, selectedRegion, latestYear)
 
   // Update the active sed_dispersal tile URL when min/max values change; clear link when stats are unavailable
   useEffect(() => {

--- a/src/components/MapContainer/MapContainer.tsx
+++ b/src/components/MapContainer/MapContainer.tsx
@@ -27,6 +27,7 @@ import { useSelectedFeatureStore } from '../../stores/selectedFeatureStore'
 import { defaultGlobalRegionOption } from '../../data/regionData'
 import useResponsive from '../../hooks/useResponsive'
 import useRasterStatistics from '../../hooks/useRasterStatistics'
+import useAvailableYears from '../../hooks/useAvailableYears'
 import { buildItemId, buildTileUrlTemplate } from '../../utils/titilerUtils'
 
 export default function MapContainer() {
@@ -41,8 +42,10 @@ export default function MapContainer() {
 
   const [searchParams, setSearchParams] = useSearchParams()
 
+  const { availableYears, defaultYear, isLoading: yearsLoading } = useAvailableYears()
+
   const year = searchParams.get('year')
-  const selectedYear = getValidYear(year)
+  const selectedYear = getValidYear(year, availableYears, defaultYear)
   const normalizedYearParam = selectedYear.toString()
   const shouldSyncYearParam = year !== normalizedYearParam
 
@@ -440,7 +443,12 @@ export default function MapContainer() {
           breadcrumb={breadcrumb}
           setBreadcrumb={setBreadcrumb}
         />
-        <YearSelect selectedYear={selectedYear} onChange={handleYearChange} />
+        <YearSelect
+          selectedYear={selectedYear}
+          onChange={handleYearChange}
+          availableYears={availableYears}
+          disabled={yearsLoading}
+        />
         <TrendsDrawer
           selectedRegion={selectedRegion}
           selectedYear={selectedYear}

--- a/src/components/YearSelect/YearSelect.stories.tsx
+++ b/src/components/YearSelect/YearSelect.stories.tsx
@@ -16,7 +16,7 @@ const StoryBookYearSelect = (props: React.ComponentProps<typeof YearSelect>) => 
 
   const handleChange = (year: number) => {
     setSelectedYear(year)
-    onChange?.(year)
+    onChange(year)
   }
 
   return <YearSelect selectedYear={selectedYear} onChange={handleChange} {...rest} />

--- a/src/components/YearSelect/YearSelect.tsx
+++ b/src/components/YearSelect/YearSelect.tsx
@@ -5,10 +5,10 @@ import clsx from 'clsx'
 
 import styles from './YearSelect.module.scss'
 import { useTranslation } from 'react-i18next'
-import { availableYears } from '../../data/mapData'
 
 export interface YearSelectProps {
   selectedYear: number
+  availableYears: number[]
   onChange?: (year: number) => void
   className?: string
   disabled?: boolean
@@ -16,6 +16,7 @@ export interface YearSelectProps {
 
 export const YearSelect = ({
   selectedYear,
+  availableYears,
   onChange,
   className,
   disabled = false,

--- a/src/components/YearSelect/YearSelect.tsx
+++ b/src/components/YearSelect/YearSelect.tsx
@@ -9,7 +9,7 @@ import { useTranslation } from 'react-i18next'
 export interface YearSelectProps {
   selectedYear: number
   availableYears: number[]
-  onChange?: (year: number) => void
+  onChange: (year: number) => void
   className?: string
   disabled?: boolean
 }
@@ -24,7 +24,7 @@ export const YearSelect = ({
   const { t } = useTranslation()
 
   const handleChange = (event: SelectChangeEvent<number>) => {
-    onChange?.(Number(event.target.value))
+    onChange(Number(event.target.value))
   }
 
   return (

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -77,6 +77,7 @@ export const SEDIMENT_EXPOSURE_2020_URL =
 export const TITILER_API_BASE_URL = 'https://mermaid.prescient.earth'
 export const TITILER_API_TIMEOUT = 10000 // 10 seconds in milliseconds
 export const SED_DISPERSAL_COLLECTION_ID = 'gpw_sediment_exposure'
+export const SED_DISPERSAL_STATS_YEAR = 2020
 
 /******MAP URL PARAMS******/
 export const LAT_LNG_PRECISION = 6

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -77,7 +77,6 @@ export const SEDIMENT_EXPOSURE_2020_URL =
 export const TITILER_API_BASE_URL = 'https://mermaid.prescient.earth'
 export const TITILER_API_TIMEOUT = 10000 // 10 seconds in milliseconds
 export const SED_DISPERSAL_COLLECTION_ID = 'gpw_sediment_exposure'
-export const SED_DISPERSAL_STATS_YEAR = 2020
 
 /******STAC API******/
 export const STAC_API_BASE_URL = 'https://mermaid.prescient.earth/stac'

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -79,6 +79,10 @@ export const TITILER_API_TIMEOUT = 10000 // 10 seconds in milliseconds
 export const SED_DISPERSAL_COLLECTION_ID = 'gpw_sediment_exposure'
 export const SED_DISPERSAL_STATS_YEAR = 2020
 
+/******STAC API******/
+export const STAC_API_BASE_URL = 'https://mermaid.prescient.earth/stac'
+export const STAC_API_TIMEOUT = 3000 // 3 seconds — metadata fetch, fail fast to fallback
+
 /******MAP URL PARAMS******/
 export const LAT_LNG_PRECISION = 6
 export const ZOOM_PRECISION = 2

--- a/src/data/mapData.ts
+++ b/src/data/mapData.ts
@@ -411,7 +411,3 @@ export const defaultLayersToShow = urlControlledLayerIds.filter(
 
 export const FALLBACK_AVAILABLE_YEARS = [2020, 2015, 2010, 2005, 2000]
 export const FALLBACK_DEFAULT_YEAR = 2020
-
-// Re-exports for backward compatibility
-export const availableYears = FALLBACK_AVAILABLE_YEARS
-export const defaultYear = FALLBACK_DEFAULT_YEAR

--- a/src/data/mapData.ts
+++ b/src/data/mapData.ts
@@ -410,4 +410,4 @@ export const defaultLayersToShow = urlControlledLayerIds.filter(
 )
 
 export const FALLBACK_AVAILABLE_YEARS = [2020, 2015, 2010, 2005, 2000]
-export const FALLBACK_DEFAULT_YEAR = 2020
+export const FALLBACK_LATEST_YEAR = 2020

--- a/src/data/mapData.ts
+++ b/src/data/mapData.ts
@@ -409,5 +409,9 @@ export const defaultLayersToShow = urlControlledLayerIds.filter(
   (id) => id !== 'lulc' && id !== 'none',
 )
 
-export const availableYears = [2020, 2015, 2010, 2005, 2000]
-export const defaultYear = 2020
+export const FALLBACK_AVAILABLE_YEARS = [2020, 2015, 2010, 2005, 2000]
+export const FALLBACK_DEFAULT_YEAR = 2020
+
+// Re-exports for backward compatibility
+export const availableYears = FALLBACK_AVAILABLE_YEARS
+export const defaultYear = FALLBACK_DEFAULT_YEAR

--- a/src/hooks/useAvailableYears.ts
+++ b/src/hooks/useAvailableYears.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react'
 import { STAC_API_BASE_URL, STAC_API_TIMEOUT, SED_DISPERSAL_COLLECTION_ID } from '../constants'
-import { FALLBACK_AVAILABLE_YEARS, FALLBACK_DEFAULT_YEAR } from '../data/mapData'
+import { FALLBACK_AVAILABLE_YEARS, FALLBACK_LATEST_YEAR } from '../data/mapData'
 
 interface AvailableYears {
   availableYears: number[]
@@ -20,7 +20,7 @@ interface StacItemsResponse {
 
 const useAvailableYears = (): AvailableYears => {
   const [availableYears, setAvailableYears] = useState<number[]>(FALLBACK_AVAILABLE_YEARS)
-  const [latestYear, setLatestYear] = useState<number>(FALLBACK_DEFAULT_YEAR)
+  const [latestYear, setLatestYear] = useState<number>(FALLBACK_LATEST_YEAR)
   const [isLoading, setIsLoading] = useState(true)
 
   useEffect(() => {
@@ -39,9 +39,9 @@ const useAvailableYears = (): AvailableYears => {
       })
       .then((data) => {
         const years = data.features
-          .map((f) => new Date(f.properties.datetime).getUTCFullYear())
-          .filter((y) => !isNaN(y))
-          .sort((a, b) => b - a)
+          .map((feature) => new Date(feature.properties.datetime).getUTCFullYear())
+          .filter((year) => !isNaN(year))
+          .sort((yearA, yearB) => yearB - yearA)
 
         if (years.length > 0) {
           setAvailableYears(years)

--- a/src/hooks/useAvailableYears.ts
+++ b/src/hooks/useAvailableYears.ts
@@ -25,6 +25,7 @@ const useAvailableYears = (): AvailableYears => {
 
   useEffect(() => {
     const controller = new AbortController()
+    let cancelled = true
     const timeoutId = setTimeout(() => controller.abort(), STAC_API_TIMEOUT)
 
     fetch(`${STAC_API_BASE_URL}/collections/${SED_DISPERSAL_COLLECTION_ID}/items`, {
@@ -38,10 +39,23 @@ const useAvailableYears = (): AvailableYears => {
         return res.json() as Promise<StacItemsResponse>
       })
       .then((data) => {
-        const years = data.features
-          .map((feature) => new Date(feature.properties.datetime).getUTCFullYear())
-          .filter((year) => !isNaN(year))
-          .sort((yearA, yearB) => yearB - yearA)
+        if (!cancelled) {
+          return
+        }
+        const years = [
+          ...new Set(
+            data.features
+              .map((feature) => {
+                const datetime = feature.properties?.datetime
+                if (typeof datetime !== 'string' || datetime.trim() === '') {
+                  return null
+                }
+                const year = new Date(datetime).getUTCFullYear()
+                return Number.isFinite(year) ? year : null
+              })
+              .filter((year): year is number => year !== null),
+          ),
+        ].sort((yearA, yearB) => yearB - yearA)
 
         if (years.length > 0) {
           setAvailableYears(years)
@@ -51,10 +65,13 @@ const useAvailableYears = (): AvailableYears => {
       })
       .catch(() => {
         clearTimeout(timeoutId)
-        setIsLoading(false)
+        if (cancelled) {
+          setIsLoading(false)
+        }
       })
 
     return () => {
+      cancelled = false
       controller.abort()
       clearTimeout(timeoutId)
     }

--- a/src/hooks/useAvailableYears.ts
+++ b/src/hooks/useAvailableYears.ts
@@ -1,0 +1,66 @@
+import { useState, useEffect } from 'react'
+import { STAC_API_BASE_URL, STAC_API_TIMEOUT, SED_DISPERSAL_COLLECTION_ID } from '../constants'
+import { FALLBACK_AVAILABLE_YEARS, FALLBACK_DEFAULT_YEAR } from '../data/mapData'
+
+interface AvailableYears {
+  availableYears: number[]
+  defaultYear: number
+  isLoading: boolean
+}
+
+interface StacFeature {
+  properties: {
+    datetime: string
+  }
+}
+
+interface StacItemsResponse {
+  features: StacFeature[]
+}
+
+const useAvailableYears = (): AvailableYears => {
+  const [availableYears, setAvailableYears] = useState<number[]>(FALLBACK_AVAILABLE_YEARS)
+  const [defaultYear, setDefaultYear] = useState<number>(FALLBACK_DEFAULT_YEAR)
+  const [isLoading, setIsLoading] = useState(true)
+
+  useEffect(() => {
+    const controller = new AbortController()
+    const timeoutId = setTimeout(() => controller.abort(), STAC_API_TIMEOUT)
+
+    fetch(`${STAC_API_BASE_URL}/collections/${SED_DISPERSAL_COLLECTION_ID}/items`, {
+      signal: controller.signal,
+    })
+      .then((res) => {
+        clearTimeout(timeoutId)
+        if (!res.ok) {
+          throw new Error()
+        }
+        return res.json() as Promise<StacItemsResponse>
+      })
+      .then((data) => {
+        const years = data.features
+          .map((f) => new Date(f.properties.datetime).getUTCFullYear())
+          .filter((y) => !isNaN(y))
+          .sort((a, b) => b - a)
+
+        if (years.length > 0) {
+          setAvailableYears(years)
+          setDefaultYear(years[0])
+        }
+        setIsLoading(false)
+      })
+      .catch(() => {
+        clearTimeout(timeoutId)
+        setIsLoading(false)
+      })
+
+    return () => {
+      controller.abort()
+      clearTimeout(timeoutId)
+    }
+  }, [])
+
+  return { availableYears, defaultYear, isLoading }
+}
+
+export default useAvailableYears

--- a/src/hooks/useAvailableYears.ts
+++ b/src/hooks/useAvailableYears.ts
@@ -4,7 +4,7 @@ import { FALLBACK_AVAILABLE_YEARS, FALLBACK_DEFAULT_YEAR } from '../data/mapData
 
 interface AvailableYears {
   availableYears: number[]
-  defaultYear: number
+  latestYear: number
   isLoading: boolean
 }
 
@@ -20,7 +20,7 @@ interface StacItemsResponse {
 
 const useAvailableYears = (): AvailableYears => {
   const [availableYears, setAvailableYears] = useState<number[]>(FALLBACK_AVAILABLE_YEARS)
-  const [defaultYear, setDefaultYear] = useState<number>(FALLBACK_DEFAULT_YEAR)
+  const [latestYear, setLatestYear] = useState<number>(FALLBACK_DEFAULT_YEAR)
   const [isLoading, setIsLoading] = useState(true)
 
   useEffect(() => {
@@ -45,7 +45,7 @@ const useAvailableYears = (): AvailableYears => {
 
         if (years.length > 0) {
           setAvailableYears(years)
-          setDefaultYear(years[0])
+          setLatestYear(years[0])
         }
         setIsLoading(false)
       })
@@ -60,7 +60,7 @@ const useAvailableYears = (): AvailableYears => {
     }
   }, [])
 
-  return { availableYears, defaultYear, isLoading }
+  return { availableYears, latestYear, isLoading }
 }
 
 export default useAvailableYears

--- a/src/hooks/useRasterStatistics.ts
+++ b/src/hooks/useRasterStatistics.ts
@@ -40,6 +40,7 @@ const useRasterStatistics = (
     const controller = new AbortController()
     let cancelled = false
 
+    // Keep stale min/max while reloading — avoids unmounting the tile layer and clearing the tile cache
     setIsLoading(true)
 
     fetchStatistics(collectionId, itemId, expression, assetBidx, controller.signal).then(

--- a/src/hooks/useRasterStatistics.ts
+++ b/src/hooks/useRasterStatistics.ts
@@ -1,7 +1,6 @@
 import { useState, useEffect } from 'react'
 import { RegionOption } from '../types/RegionDataTypes'
 import { buildExpression, buildItemId, fetchStatistics } from '../utils/titilerUtils'
-import { SED_DISPERSAL_STATS_YEAR } from '../constants'
 
 interface RasterStatistics {
   minValue: number | null
@@ -19,6 +18,7 @@ const statsCache = new Map<string, CachedStats>()
 const useRasterStatistics = (
   collectionId: string,
   selectedRegion: RegionOption,
+  statsYear: number,
 ): RasterStatistics => {
   const [minValue, setMinValue] = useState<number | null>(null)
   const [maxValue, setMaxValue] = useState<number | null>(null)
@@ -26,7 +26,7 @@ const useRasterStatistics = (
 
   useEffect(() => {
     const { expression, assetBidx } = buildExpression(selectedRegion)
-    const itemId = buildItemId(SED_DISPERSAL_STATS_YEAR)
+    const itemId = buildItemId(statsYear)
     const cacheKey = `${collectionId}|${itemId}|${expression ?? 'global'}`
 
     const cached = statsCache.get(cacheKey)
@@ -60,7 +60,7 @@ const useRasterStatistics = (
       cancelled = true
       controller.abort()
     }
-  }, [collectionId, selectedRegion])
+  }, [collectionId, selectedRegion, statsYear])
 
   return { minValue, maxValue, isLoading }
 }

--- a/src/hooks/useRasterStatistics.ts
+++ b/src/hooks/useRasterStatistics.ts
@@ -18,7 +18,7 @@ const statsCache = new Map<string, CachedStats>()
 const useRasterStatistics = (
   collectionId: string,
   selectedRegion: RegionOption,
-  statsYear: number,
+  latestYear: number,
 ): RasterStatistics => {
   const [minValue, setMinValue] = useState<number | null>(null)
   const [maxValue, setMaxValue] = useState<number | null>(null)
@@ -26,7 +26,7 @@ const useRasterStatistics = (
 
   useEffect(() => {
     const { expression, assetBidx } = buildExpression(selectedRegion)
-    const itemId = buildItemId(statsYear)
+    const itemId = buildItemId(latestYear)
     const cacheKey = `${collectionId}|${itemId}|${expression ?? 'global'}`
 
     const cached = statsCache.get(cacheKey)
@@ -61,7 +61,7 @@ const useRasterStatistics = (
       cancelled = true
       controller.abort()
     }
-  }, [collectionId, selectedRegion, statsYear])
+  }, [collectionId, selectedRegion, latestYear])
 
   return { minValue, maxValue, isLoading }
 }

--- a/src/hooks/useRasterStatistics.ts
+++ b/src/hooks/useRasterStatistics.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react'
 import { RegionOption } from '../types/RegionDataTypes'
 import { buildExpression, buildItemId, fetchStatistics } from '../utils/titilerUtils'
+import { SED_DISPERSAL_STATS_YEAR } from '../constants'
 
 interface RasterStatistics {
   minValue: number | null
@@ -18,7 +19,6 @@ const statsCache = new Map<string, CachedStats>()
 const useRasterStatistics = (
   collectionId: string,
   selectedRegion: RegionOption,
-  selectedYear: number,
 ): RasterStatistics => {
   const [minValue, setMinValue] = useState<number | null>(null)
   const [maxValue, setMaxValue] = useState<number | null>(null)
@@ -26,7 +26,7 @@ const useRasterStatistics = (
 
   useEffect(() => {
     const { expression, assetBidx } = buildExpression(selectedRegion)
-    const itemId = buildItemId(selectedYear)
+    const itemId = buildItemId(SED_DISPERSAL_STATS_YEAR)
     const cacheKey = `${collectionId}|${itemId}|${expression ?? 'global'}`
 
     const cached = statsCache.get(cacheKey)
@@ -40,8 +40,6 @@ const useRasterStatistics = (
     const controller = new AbortController()
     let cancelled = false
 
-    // Don't reset min/max to null — keep stale values while loading so the layer
-    // stays mounted in MapLibre and the tile cache stays warm.
     setIsLoading(true)
 
     fetchStatistics(collectionId, itemId, expression, assetBidx, controller.signal).then(
@@ -62,7 +60,7 @@ const useRasterStatistics = (
       cancelled = true
       controller.abort()
     }
-  }, [collectionId, selectedRegion, selectedYear])
+  }, [collectionId, selectedRegion])
 
   return { minValue, maxValue, isLoading }
 }

--- a/src/tests/chartUtils.test.ts
+++ b/src/tests/chartUtils.test.ts
@@ -290,7 +290,7 @@ describe('chart data utilities', () => {
     })
 
     describe('sediment_load_historical special handling', () => {
-      it('should divide values by 1000000 for sediment data', () => {
+      it('should pass sediment values through without unit conversion', () => {
         const mockData: ChartData = {
           sediment: {
             '2020': 5000000,
@@ -300,7 +300,7 @@ describe('chart data utilities', () => {
 
         const result = mapChartConfigToData(mockData, 'sediment_load_historical')
 
-        expect(result.chartSeriesData[0].y).toEqual([3, 5])
+        expect(result.chartSeriesData[0].y).toEqual([3000000, 5000000])
       })
 
       it('should use tonnage format in hover template for sediment', () => {

--- a/src/tests/mapUtils.test.ts
+++ b/src/tests/mapUtils.test.ts
@@ -655,7 +655,7 @@ describe('map utilities', () => {
       const map = makeQueryMap()
       const onResult = jest.fn()
 
-      querySourceFeatureWhenReady(
+      const cancel = querySourceFeatureWhenReady(
         map,
         'src',
         'layer',
@@ -666,6 +666,7 @@ describe('map utilities', () => {
 
       expect(onResult).not.toHaveBeenCalled()
       expect(map.on).toHaveBeenCalledWith('sourcedata', expect.any(Function))
+      cancel()
     })
 
     it('calls onResult with the feature once the sourcedata event fires', () => {

--- a/src/tests/routeUtils.test.ts
+++ b/src/tests/routeUtils.test.ts
@@ -10,7 +10,7 @@ import {
 
 jest.mock('../data/mapData', () => ({
   FALLBACK_AVAILABLE_YEARS: [2020, 2015, 2010, 2005, 2000],
-  FALLBACK_DEFAULT_YEAR: 2020,
+  FALLBACK_LATEST_YEAR: 2020,
   defaultLayersToShow: ['sed_export', 'sed_dispersal', 'plumes'],
   urlControlledLayerIds: ['none', 'sed_export', 'lulc', 'sed_dispersal', 'plumes'],
 }))
@@ -67,7 +67,7 @@ describe('route parameter utilities', () => {
 
   describe('getValidYear', () => {
     it.each([null, 'not-a-year', '1999', '2025'] as const)(
-      'returns defaultYear (2020) for invalid input (%s)',
+      'returns latestYear fallback (2020) for invalid input (%s)',
       (input) => {
         expect(getValidYear(input)).toBe(2020)
       },

--- a/src/tests/routeUtils.test.ts
+++ b/src/tests/routeUtils.test.ts
@@ -11,8 +11,6 @@ import {
 jest.mock('../data/mapData', () => ({
   FALLBACK_AVAILABLE_YEARS: [2020, 2015, 2010, 2005, 2000],
   FALLBACK_DEFAULT_YEAR: 2020,
-  availableYears: [2020, 2015, 2010, 2005, 2000],
-  defaultYear: 2020,
   defaultLayersToShow: ['sed_export', 'sed_dispersal', 'plumes'],
   urlControlledLayerIds: ['none', 'sed_export', 'lulc', 'sed_dispersal', 'plumes'],
 }))

--- a/src/tests/routeUtils.test.ts
+++ b/src/tests/routeUtils.test.ts
@@ -9,6 +9,8 @@ import {
 } from '../utils/routeUtils'
 
 jest.mock('../data/mapData', () => ({
+  FALLBACK_AVAILABLE_YEARS: [2020, 2015, 2010, 2005, 2000],
+  FALLBACK_DEFAULT_YEAR: 2020,
   availableYears: [2020, 2015, 2010, 2005, 2000],
   defaultYear: 2020,
   defaultLayersToShow: ['sed_export', 'sed_dispersal', 'plumes'],

--- a/src/tests/useAvailableYears.test.ts
+++ b/src/tests/useAvailableYears.test.ts
@@ -3,7 +3,7 @@
  */
 import { renderHook, waitFor } from '@testing-library/react'
 import useAvailableYears from '../hooks/useAvailableYears'
-import { FALLBACK_AVAILABLE_YEARS, FALLBACK_DEFAULT_YEAR } from '../data/mapData'
+import { FALLBACK_AVAILABLE_YEARS, FALLBACK_LATEST_YEAR } from '../data/mapData'
 
 const makeStacResponse = (years: number[]) => ({
   features: years.map((y) => ({
@@ -29,7 +29,7 @@ describe('useAvailableYears', () => {
     const { result } = renderHook(() => useAvailableYears())
     expect(result.current.isLoading).toBe(true)
     expect(result.current.availableYears).toEqual(FALLBACK_AVAILABLE_YEARS)
-    expect(result.current.latestYear).toBe(FALLBACK_DEFAULT_YEAR)
+    expect(result.current.latestYear).toBe(FALLBACK_LATEST_YEAR)
   })
 
   it('returns fetched years sorted descending and sets isLoading false on success', async () => {
@@ -52,7 +52,7 @@ describe('useAvailableYears', () => {
     await waitFor(() => expect(result.current.isLoading).toBe(false))
 
     expect(result.current.availableYears).toEqual(FALLBACK_AVAILABLE_YEARS)
-    expect(result.current.latestYear).toBe(FALLBACK_DEFAULT_YEAR)
+    expect(result.current.latestYear).toBe(FALLBACK_LATEST_YEAR)
   })
 
   it('falls back to hardcoded values on non-ok response', async () => {
@@ -64,7 +64,7 @@ describe('useAvailableYears', () => {
     await waitFor(() => expect(result.current.isLoading).toBe(false))
 
     expect(result.current.availableYears).toEqual(FALLBACK_AVAILABLE_YEARS)
-    expect(result.current.latestYear).toBe(FALLBACK_DEFAULT_YEAR)
+    expect(result.current.latestYear).toBe(FALLBACK_LATEST_YEAR)
   })
 
   it('does not re-fetch when re-rendered without argument changes', async () => {

--- a/src/tests/useAvailableYears.test.ts
+++ b/src/tests/useAvailableYears.test.ts
@@ -1,0 +1,87 @@
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook, waitFor } from '@testing-library/react'
+import useAvailableYears from '../hooks/useAvailableYears'
+import { FALLBACK_AVAILABLE_YEARS, FALLBACK_DEFAULT_YEAR } from '../data/mapData'
+
+const makeStacResponse = (years: number[]) => ({
+  features: years.map((y) => ({
+    id: `gpw_sediment_exposure_${y}`,
+    properties: { datetime: `${y}-01-01T00:00:00Z` },
+  })),
+})
+
+// jsdom doesn't include fetch — stub it so jest.spyOn can target it
+const originalFetch = global.fetch
+beforeAll(() => {
+  global.fetch = jest.fn()
+})
+afterAll(() => {
+  global.fetch = originalFetch
+})
+
+describe('useAvailableYears', () => {
+  afterEach(() => jest.restoreAllMocks())
+
+  it('starts with fallback values and isLoading true', () => {
+    jest.spyOn(global, 'fetch').mockReturnValue(new Promise(() => {}))
+    const { result } = renderHook(() => useAvailableYears())
+    expect(result.current.isLoading).toBe(true)
+    expect(result.current.availableYears).toEqual(FALLBACK_AVAILABLE_YEARS)
+    expect(result.current.defaultYear).toBe(FALLBACK_DEFAULT_YEAR)
+  })
+
+  it('returns fetched years sorted descending and sets isLoading false on success', async () => {
+    jest.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(makeStacResponse([2000, 2010, 2020, 2005, 2015])),
+    } as Response)
+
+    const { result } = renderHook(() => useAvailableYears())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    expect(result.current.availableYears).toEqual([2020, 2015, 2010, 2005, 2000])
+    expect(result.current.defaultYear).toBe(2020)
+  })
+
+  it('falls back to hardcoded values on network error', async () => {
+    jest.spyOn(global, 'fetch').mockRejectedValue(new Error('network'))
+
+    const { result } = renderHook(() => useAvailableYears())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    expect(result.current.availableYears).toEqual(FALLBACK_AVAILABLE_YEARS)
+    expect(result.current.defaultYear).toBe(FALLBACK_DEFAULT_YEAR)
+  })
+
+  it('falls back to hardcoded values on non-ok response', async () => {
+    jest.spyOn(global, 'fetch').mockResolvedValue({
+      ok: false,
+    } as Response)
+
+    const { result } = renderHook(() => useAvailableYears())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    expect(result.current.availableYears).toEqual(FALLBACK_AVAILABLE_YEARS)
+    expect(result.current.defaultYear).toBe(FALLBACK_DEFAULT_YEAR)
+  })
+
+  it('does not re-fetch when re-rendered without argument changes', async () => {
+    const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(makeStacResponse([2020, 2015, 2010, 2005, 2000])),
+    } as Response)
+
+    const { rerender, result } = renderHook(() => useAvailableYears())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    // Capture call count after initial load (may be >1 in React Strict Mode)
+    const callCountAfterMount = fetchSpy.mock.calls.length
+    expect(callCountAfterMount).toBeGreaterThanOrEqual(1)
+
+    rerender()
+    // Re-render must not trigger an additional fetch
+    expect(fetchSpy.mock.calls.length).toBe(callCountAfterMount)
+  })
+})

--- a/src/tests/useAvailableYears.test.ts
+++ b/src/tests/useAvailableYears.test.ts
@@ -29,7 +29,7 @@ describe('useAvailableYears', () => {
     const { result } = renderHook(() => useAvailableYears())
     expect(result.current.isLoading).toBe(true)
     expect(result.current.availableYears).toEqual(FALLBACK_AVAILABLE_YEARS)
-    expect(result.current.defaultYear).toBe(FALLBACK_DEFAULT_YEAR)
+    expect(result.current.latestYear).toBe(FALLBACK_DEFAULT_YEAR)
   })
 
   it('returns fetched years sorted descending and sets isLoading false on success', async () => {
@@ -42,7 +42,7 @@ describe('useAvailableYears', () => {
     await waitFor(() => expect(result.current.isLoading).toBe(false))
 
     expect(result.current.availableYears).toEqual([2020, 2015, 2010, 2005, 2000])
-    expect(result.current.defaultYear).toBe(2020)
+    expect(result.current.latestYear).toBe(2020)
   })
 
   it('falls back to hardcoded values on network error', async () => {
@@ -52,7 +52,7 @@ describe('useAvailableYears', () => {
     await waitFor(() => expect(result.current.isLoading).toBe(false))
 
     expect(result.current.availableYears).toEqual(FALLBACK_AVAILABLE_YEARS)
-    expect(result.current.defaultYear).toBe(FALLBACK_DEFAULT_YEAR)
+    expect(result.current.latestYear).toBe(FALLBACK_DEFAULT_YEAR)
   })
 
   it('falls back to hardcoded values on non-ok response', async () => {
@@ -64,7 +64,7 @@ describe('useAvailableYears', () => {
     await waitFor(() => expect(result.current.isLoading).toBe(false))
 
     expect(result.current.availableYears).toEqual(FALLBACK_AVAILABLE_YEARS)
-    expect(result.current.defaultYear).toBe(FALLBACK_DEFAULT_YEAR)
+    expect(result.current.latestYear).toBe(FALLBACK_DEFAULT_YEAR)
   })
 
   it('does not re-fetch when re-rendered without argument changes', async () => {

--- a/src/tests/useRasterStatistics.test.ts
+++ b/src/tests/useRasterStatistics.test.ts
@@ -5,6 +5,7 @@ import { renderHook, waitFor } from '@testing-library/react'
 import useRasterStatistics from '../hooks/useRasterStatistics'
 import * as titilerUtils from '../utils/titilerUtils'
 import { RegionOption } from '../types/RegionDataTypes'
+import { SED_DISPERSAL_STATS_YEAR } from '../constants'
 
 // Avoid importing LngLat directly — maplibre-gl uses browser APIs unavailable in jsdom
 const makeRegion = (overrides: Partial<RegionOption> = {}): RegionOption =>
@@ -26,7 +27,7 @@ describe('useRasterStatistics', () => {
 
   it('starts with null values and isLoading true', () => {
     jest.spyOn(titilerUtils, 'fetchStatistics').mockReturnValue(new Promise(() => {}))
-    const { result } = renderHook(() => useRasterStatistics(nextCollection(), makeRegion(), 2000))
+    const { result } = renderHook(() => useRasterStatistics(nextCollection(), makeRegion()))
     expect(result.current.isLoading).toBe(true)
     expect(result.current.minValue).toBeNull()
     expect(result.current.maxValue).toBeNull()
@@ -34,7 +35,7 @@ describe('useRasterStatistics', () => {
 
   it('returns min/max and clears loading after a successful fetch', async () => {
     jest.spyOn(titilerUtils, 'fetchStatistics').mockResolvedValue({ min: 1.5, max: 99.9 })
-    const { result } = renderHook(() => useRasterStatistics(nextCollection(), makeRegion(), 2000))
+    const { result } = renderHook(() => useRasterStatistics(nextCollection(), makeRegion()))
     await waitFor(() => expect(result.current.isLoading).toBe(false))
     expect(result.current.minValue).toBe(1.5)
     expect(result.current.maxValue).toBe(99.9)
@@ -42,7 +43,7 @@ describe('useRasterStatistics', () => {
 
   it('sets isLoading false and keeps null values when API returns null', async () => {
     jest.spyOn(titilerUtils, 'fetchStatistics').mockResolvedValue(null)
-    const { result } = renderHook(() => useRasterStatistics(nextCollection(), makeRegion(), 2000))
+    const { result } = renderHook(() => useRasterStatistics(nextCollection(), makeRegion()))
     await waitFor(() => expect(result.current.isLoading).toBe(false))
     expect(result.current.minValue).toBeNull()
     expect(result.current.maxValue).toBeNull()
@@ -53,7 +54,7 @@ describe('useRasterStatistics', () => {
       .spyOn(titilerUtils, 'fetchStatistics')
       .mockResolvedValue({ min: 0, max: 10 })
     const region = makeRegion({ regionType: 'country', bandId: 42 })
-    const { result } = renderHook(() => useRasterStatistics(nextCollection(), region, 2000))
+    const { result } = renderHook(() => useRasterStatistics(nextCollection(), region))
     await waitFor(() => expect(result.current.isLoading).toBe(false))
     expect(fetchSpy).toHaveBeenCalledWith(
       expect.any(String),
@@ -64,6 +65,16 @@ describe('useRasterStatistics', () => {
     )
   })
 
+  it('always fetches stats using the latest stats year regardless of selected year', async () => {
+    const fetchSpy = jest
+      .spyOn(titilerUtils, 'fetchStatistics')
+      .mockResolvedValue({ min: 0, max: 10 })
+    const collectionId = nextCollection()
+    const { result } = renderHook(() => useRasterStatistics(collectionId, makeRegion()))
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(fetchSpy.mock.calls[0][1]).toBe(`gpw_sediment_exposure_${SED_DISPERSAL_STATS_YEAR}`)
+  })
+
   it('serves a cached result synchronously without re-fetching', async () => {
     const fetchSpy = jest
       .spyOn(titilerUtils, 'fetchStatistics')
@@ -72,32 +83,33 @@ describe('useRasterStatistics', () => {
     const region = makeRegion()
 
     // First render — populates cache
-    const { result: r1, unmount } = renderHook(() =>
-      useRasterStatistics(collectionId, region, 2000),
-    )
+    const { result: r1, unmount } = renderHook(() => useRasterStatistics(collectionId, region))
     await waitFor(() => expect(r1.current.isLoading).toBe(false))
     unmount()
 
     // Second render with same params — should hit cache immediately (isLoading stays false)
-    const { result: r2 } = renderHook(() => useRasterStatistics(collectionId, region, 2000))
+    const { result: r2 } = renderHook(() => useRasterStatistics(collectionId, region))
     expect(r2.current.isLoading).toBe(false)
     expect(r2.current.minValue).toBe(5)
     expect(r2.current.maxValue).toBe(50)
     expect(fetchSpy).toHaveBeenCalledTimes(1)
   })
 
-  it('resets to loading and re-fetches when year changes', async () => {
-    jest.spyOn(titilerUtils, 'fetchStatistics').mockResolvedValue({ min: 10, max: 200 })
+  it('does not re-fetch when year changes', async () => {
+    const fetchSpy = jest
+      .spyOn(titilerUtils, 'fetchStatistics')
+      .mockResolvedValue({ min: 10, max: 200 })
     const collectionId = nextCollection()
     const region = makeRegion()
-    let year = 2010
 
-    const { result, rerender } = renderHook(() => useRasterStatistics(collectionId, region, year))
+    // Render hook — year is not a parameter, so we simulate a parent re-render with a new year
+    // by re-rendering with no argument change (hook has no year param)
+    const { result, rerender } = renderHook(() => useRasterStatistics(collectionId, region))
     await waitFor(() => expect(result.current.isLoading).toBe(false))
 
-    year = 2015
     rerender()
-    expect(result.current.isLoading).toBe(true)
-    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    // Still not loading — no re-fetch triggered
+    expect(result.current.isLoading).toBe(false)
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/tests/useRasterStatistics.test.ts
+++ b/src/tests/useRasterStatistics.test.ts
@@ -5,7 +5,6 @@ import { renderHook, waitFor } from '@testing-library/react'
 import useRasterStatistics from '../hooks/useRasterStatistics'
 import * as titilerUtils from '../utils/titilerUtils'
 import { RegionOption } from '../types/RegionDataTypes'
-import { SED_DISPERSAL_STATS_YEAR } from '../constants'
 
 // Avoid importing LngLat directly — maplibre-gl uses browser APIs unavailable in jsdom
 const makeRegion = (overrides: Partial<RegionOption> = {}): RegionOption =>
@@ -27,7 +26,7 @@ describe('useRasterStatistics', () => {
 
   it('starts with null values and isLoading true', () => {
     jest.spyOn(titilerUtils, 'fetchStatistics').mockReturnValue(new Promise(() => {}))
-    const { result } = renderHook(() => useRasterStatistics(nextCollection(), makeRegion()))
+    const { result } = renderHook(() => useRasterStatistics(nextCollection(), makeRegion(), 2020))
     expect(result.current.isLoading).toBe(true)
     expect(result.current.minValue).toBeNull()
     expect(result.current.maxValue).toBeNull()
@@ -35,7 +34,7 @@ describe('useRasterStatistics', () => {
 
   it('returns min/max and clears loading after a successful fetch', async () => {
     jest.spyOn(titilerUtils, 'fetchStatistics').mockResolvedValue({ min: 1.5, max: 99.9 })
-    const { result } = renderHook(() => useRasterStatistics(nextCollection(), makeRegion()))
+    const { result } = renderHook(() => useRasterStatistics(nextCollection(), makeRegion(), 2020))
     await waitFor(() => expect(result.current.isLoading).toBe(false))
     expect(result.current.minValue).toBe(1.5)
     expect(result.current.maxValue).toBe(99.9)
@@ -43,7 +42,7 @@ describe('useRasterStatistics', () => {
 
   it('sets isLoading false and keeps null values when API returns null', async () => {
     jest.spyOn(titilerUtils, 'fetchStatistics').mockResolvedValue(null)
-    const { result } = renderHook(() => useRasterStatistics(nextCollection(), makeRegion()))
+    const { result } = renderHook(() => useRasterStatistics(nextCollection(), makeRegion(), 2020))
     await waitFor(() => expect(result.current.isLoading).toBe(false))
     expect(result.current.minValue).toBeNull()
     expect(result.current.maxValue).toBeNull()
@@ -54,7 +53,7 @@ describe('useRasterStatistics', () => {
       .spyOn(titilerUtils, 'fetchStatistics')
       .mockResolvedValue({ min: 0, max: 10 })
     const region = makeRegion({ regionType: 'country', bandId: 42 })
-    const { result } = renderHook(() => useRasterStatistics(nextCollection(), region))
+    const { result } = renderHook(() => useRasterStatistics(nextCollection(), region, 2020))
     await waitFor(() => expect(result.current.isLoading).toBe(false))
     expect(fetchSpy).toHaveBeenCalledWith(
       expect.any(String),
@@ -65,14 +64,14 @@ describe('useRasterStatistics', () => {
     )
   })
 
-  it('always fetches stats using the latest stats year regardless of selected year', async () => {
+  it('uses the provided statsYear to build the item ID', async () => {
     const fetchSpy = jest
       .spyOn(titilerUtils, 'fetchStatistics')
       .mockResolvedValue({ min: 0, max: 10 })
     const collectionId = nextCollection()
-    const { result } = renderHook(() => useRasterStatistics(collectionId, makeRegion()))
+    const { result } = renderHook(() => useRasterStatistics(collectionId, makeRegion(), 2020))
     await waitFor(() => expect(result.current.isLoading).toBe(false))
-    expect(fetchSpy.mock.calls[0][1]).toBe(`gpw_sediment_exposure_${SED_DISPERSAL_STATS_YEAR}`)
+    expect(fetchSpy.mock.calls[0][1]).toBe('gpw_sediment_exposure_2020')
   })
 
   it('serves a cached result synchronously without re-fetching', async () => {
@@ -83,33 +82,34 @@ describe('useRasterStatistics', () => {
     const region = makeRegion()
 
     // First render — populates cache
-    const { result: r1, unmount } = renderHook(() => useRasterStatistics(collectionId, region))
+    const { result: r1, unmount } = renderHook(() =>
+      useRasterStatistics(collectionId, region, 2020),
+    )
     await waitFor(() => expect(r1.current.isLoading).toBe(false))
     unmount()
 
     // Second render with same params — should hit cache immediately (isLoading stays false)
-    const { result: r2 } = renderHook(() => useRasterStatistics(collectionId, region))
+    const { result: r2 } = renderHook(() => useRasterStatistics(collectionId, region, 2020))
     expect(r2.current.isLoading).toBe(false)
     expect(r2.current.minValue).toBe(5)
     expect(r2.current.maxValue).toBe(50)
     expect(fetchSpy).toHaveBeenCalledTimes(1)
   })
 
-  it('does not re-fetch when year changes', async () => {
-    const fetchSpy = jest
-      .spyOn(titilerUtils, 'fetchStatistics')
-      .mockResolvedValue({ min: 10, max: 200 })
+  it('re-fetches when statsYear changes', async () => {
+    jest.spyOn(titilerUtils, 'fetchStatistics').mockResolvedValue({ min: 10, max: 200 })
     const collectionId = nextCollection()
     const region = makeRegion()
+    let statsYear = 2020
 
-    // Render hook — year is not a parameter, so we simulate a parent re-render with a new year
-    // by re-rendering with no argument change (hook has no year param)
-    const { result, rerender } = renderHook(() => useRasterStatistics(collectionId, region))
+    const { result, rerender } = renderHook(() =>
+      useRasterStatistics(collectionId, region, statsYear),
+    )
     await waitFor(() => expect(result.current.isLoading).toBe(false))
 
+    statsYear = 2015
     rerender()
-    // Still not loading — no re-fetch triggered
-    expect(result.current.isLoading).toBe(false)
-    expect(fetchSpy).toHaveBeenCalledTimes(1)
+    expect(result.current.isLoading).toBe(true)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
   })
 })

--- a/src/tests/useRasterStatistics.test.ts
+++ b/src/tests/useRasterStatistics.test.ts
@@ -64,7 +64,7 @@ describe('useRasterStatistics', () => {
     )
   })
 
-  it('uses the provided statsYear to build the item ID', async () => {
+  it('uses the provided latestYear to build the item ID', async () => {
     const fetchSpy = jest
       .spyOn(titilerUtils, 'fetchStatistics')
       .mockResolvedValue({ min: 0, max: 10 })
@@ -96,18 +96,18 @@ describe('useRasterStatistics', () => {
     expect(fetchSpy).toHaveBeenCalledTimes(1)
   })
 
-  it('re-fetches when statsYear changes', async () => {
+  it('re-fetches when latestYear changes', async () => {
     jest.spyOn(titilerUtils, 'fetchStatistics').mockResolvedValue({ min: 10, max: 200 })
     const collectionId = nextCollection()
     const region = makeRegion()
-    let statsYear = 2020
+    let latestYear = 2020
 
     const { result, rerender } = renderHook(() =>
-      useRasterStatistics(collectionId, region, statsYear),
+      useRasterStatistics(collectionId, region, latestYear),
     )
     await waitFor(() => expect(result.current.isLoading).toBe(false))
 
-    statsYear = 2015
+    latestYear = 2015
     rerender()
     expect(result.current.isLoading).toBe(true)
     await waitFor(() => expect(result.current.isLoading).toBe(false))

--- a/src/utils/routeUtils.ts
+++ b/src/utils/routeUtils.ts
@@ -1,6 +1,6 @@
 import {
   FALLBACK_AVAILABLE_YEARS,
-  FALLBACK_DEFAULT_YEAR,
+  FALLBACK_LATEST_YEAR,
   defaultLayersToShow,
   urlControlledLayerIds,
 } from '../data/mapData'
@@ -32,7 +32,7 @@ export function getValidWatershed(watershedFromSearchParam: string | null): stri
 export function getValidYear(
   yearFromSearchParam: string | null,
   years: number[] = FALLBACK_AVAILABLE_YEARS,
-  fallback: number = FALLBACK_DEFAULT_YEAR,
+  fallback: number = FALLBACK_LATEST_YEAR,
 ): number {
   const parsedYear = Number(yearFromSearchParam)
   return years.includes(parsedYear) ? parsedYear : fallback

--- a/src/utils/routeUtils.ts
+++ b/src/utils/routeUtils.ts
@@ -1,7 +1,7 @@
 import {
-  availableYears,
+  FALLBACK_AVAILABLE_YEARS,
+  FALLBACK_DEFAULT_YEAR,
   defaultLayersToShow,
-  defaultYear,
   urlControlledLayerIds,
 } from '../data/mapData'
 import { defaultGlobalRegionOption, regionOptions } from '../data/regionData'
@@ -29,9 +29,13 @@ export function getValidWatershed(watershedFromSearchParam: string | null): stri
   return watershedFromSearchParam.trim()
 }
 
-export function getValidYear(yearFromSearchParam: string | null) {
+export function getValidYear(
+  yearFromSearchParam: string | null,
+  years: number[] = FALLBACK_AVAILABLE_YEARS,
+  fallback: number = FALLBACK_DEFAULT_YEAR,
+): number {
   const parsedYear = Number(yearFromSearchParam)
-  return availableYears.includes(parsedYear) ? parsedYear : defaultYear
+  return years.includes(parsedYear) ? parsedYear : fallback
 }
 
 export function getValidLayers(layersFromSearchParam: string | null) {


### PR DESCRIPTION
### Dynamic color ramp & year discovery for sediment dispersal

  - Available years and latest year are fetched from the STAC catalog on load, with hardcoded fallback if the
  fetch fails; year selector is disabled while loading
  - Sediment dispersal color ramp anchored to latest year's stats only — switching years no longer re-fetches
  stats or causes a loading flash; results are cached
  - Fixed stale test assertions and a timer leak carried over from previous PRs

## Every PR

Before merging, the developer of this pull request has checked the following:

- [x] Changes have been tested locally without errors
- [x] Lint has run and any errors have been resolved
- [x] Prettier has run on any changed files
- [x] Storybook stories have run and any errors have been resolved
- [x] Pre-existing unit tests have run and passed
  - [x] Unit tests have been added or updated, where possible, to prevent future regressions

## Post-Merge

- [ ] Code has merged and build success is confirmed in 'Actions'
- [ ] The corresponding Trello ticket has moved to the appropriate list (likely User-QA)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added dynamic year data fetching from STAC API with loading state indicator on year selector.

* **Bug Fixes**
  * Fixed sediment load data calculations to display correct values.

* **Refactor**
  * Renamed internal year constants for consistency.
  * Restructured year selection logic to derive from dynamic sources.
  * Updated raster statistics processing for improved data handling.

* **Tests**
  * Added comprehensive test coverage for year-fetching functionality.
  * Updated existing tests to reflect new year handling behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/data-mermaid/clean-reefs-ui/pull/115?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->