### PR TITLE
feat: [C214]: Add rivers-emphasis layer from MapTiler waterway source-layer

### DIFF
--- a/src/assets/crosshair-cursor.svg
+++ b/src/assets/crosshair-cursor.svg
@@ -1,6 +1,22 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none">
-  <line x1="10" y1="1" x2="10" y2="7" stroke="#00FF01" stroke-width="2" stroke-linecap="round"/>
-  <line x1="10" y1="13" x2="10" y2="19" stroke="#00FF01" stroke-width="2" stroke-linecap="round"/>
-  <line x1="1" y1="10" x2="7" y2="10" stroke="#00FF01" stroke-width="2" stroke-linecap="round"/>
-  <line x1="13" y1="10" x2="19" y2="10" stroke="#00FF01" stroke-width="2" stroke-linecap="round"/>
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_4577_28115)">
+<g filter="url(#filter0_d_4577_28115)">
+<path d="M10 1V7M10 13V19M1 10H7M13 10H19" stroke="#FF0000" stroke-width="2" stroke-linecap="round"/>
+</g>
+</g>
+<defs>
+<filter id="filter0_d_4577_28115" x="-1" y="-1" width="24" height="24" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="1" dy="1"/>
+<feGaussianBlur stdDeviation="1"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.5 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_4577_28115"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_4577_28115" result="shape"/>
+</filter>
+<clipPath id="clip0_4577_28115">
+<rect width="20" height="20" fill="white"/>
+</clipPath>
+</defs>
 </svg>

--- a/src/components/BaseMap/BaseMap.module.scss
+++ b/src/components/BaseMap/BaseMap.module.scss
@@ -18,7 +18,7 @@
 .plume-marker {
   width: 15px;
   height: 15px;
-  border: 2px solid theme.$accentBlue;
+  border: 2px solid theme.$activeSelection;
   border-radius: 5px;
   background: transparent;
   pointer-events: none;

--- a/src/components/BaseMap/BaseMap.tsx
+++ b/src/components/BaseMap/BaseMap.tsx
@@ -1041,7 +1041,7 @@ export default function BaseMap({
             filter={['==', ['get', 'class'], 'river']}
             paint={{
               'line-color': 'white',
-              'line-width': 3,//['interpolate', ['linear'], ['zoom'], 0, 0.5, 5, 1, 10, 1.5, 15, 2],
+              'line-width': 3,
             }}
           />
         )}
@@ -1055,7 +1055,6 @@ export default function BaseMap({
             filter={['==', ['get', 'class'], 'river']}
             paint={{
               'line-color': 'darkblue',
-              // 'line-width': ['interpolate', ['linear'], ['zoom'], 0, 0.5, 5, 1, 10, 1.5, 15, 2],
               'line-width': ['interpolate', ['linear'], ['zoom'], 0, 1.5, 6, 2, 11, 2.5, 16, 3],
             }}
           />

--- a/src/components/BaseMap/BaseMap.tsx
+++ b/src/components/BaseMap/BaseMap.tsx
@@ -1033,6 +1033,20 @@ export default function BaseMap({
         )}
         {isMapLoaded && (
           <Layer
+            id="rivers-emphasis-border"
+            type="line"
+            source={selectedBasemap === 'satellite' ? 'maptiler_planet' : 'maptiler_planet_v4'}
+            source-layer="waterway"
+            beforeId={basemapBeforeId}
+            filter={['==', ['get', 'class'], 'river']}
+            paint={{
+              'line-color': 'white',
+              'line-width': 3,//['interpolate', ['linear'], ['zoom'], 0, 0.5, 5, 1, 10, 1.5, 15, 2],
+            }}
+          />
+        )}
+        {isMapLoaded && (
+          <Layer
             id="rivers-emphasis"
             type="line"
             source={selectedBasemap === 'satellite' ? 'maptiler_planet' : 'maptiler_planet_v4'}
@@ -1040,8 +1054,9 @@ export default function BaseMap({
             beforeId={basemapBeforeId}
             filter={['==', ['get', 'class'], 'river']}
             paint={{
-              'line-color': '#87CEEB',
-              'line-width': ['interpolate', ['linear'], ['zoom'], 0, 0.5, 5, 1, 10, 1.5, 15, 2],
+              'line-color': 'darkblue',
+              // 'line-width': ['interpolate', ['linear'], ['zoom'], 0, 0.5, 5, 1, 10, 1.5, 15, 2],
+              'line-width': ['interpolate', ['linear'], ['zoom'], 0, 1.5, 6, 2, 11, 2.5, 16, 3],
             }}
           />
         )}

--- a/src/components/BaseMap/BaseMap.tsx
+++ b/src/components/BaseMap/BaseMap.tsx
@@ -1012,7 +1012,7 @@ export default function BaseMap({
         )}
         {/* Layer visual stack (bottom → top):
             base style → COG (lulc/sed_export) → rastertiles (sed_dispersal/reef_extent)
-            → benthic → regions/countries → watershed → plumes → shoreline → map labels
+            → benthic → regions/countries → watershed → plumes → shoreline → rivers → map labels
             Shoreline mounts first so it exists as the beforeId anchor for the overlays below. */}
         {isMapLoaded && (
           <Layer
@@ -1028,6 +1028,20 @@ export default function BaseMap({
             paint={{
               'line-color': '#000',
               'line-width': ['interpolate', ['linear'], ['zoom'], 0, 0.5, 5, 1, 10, 1.75, 15, 2.5],
+            }}
+          />
+        )}
+        {isMapLoaded && (
+          <Layer
+            id="rivers-emphasis"
+            type="line"
+            source={selectedBasemap === 'satellite' ? 'maptiler_planet' : 'maptiler_planet_v4'}
+            source-layer="waterway"
+            beforeId={basemapBeforeId}
+            filter={['==', ['get', 'class'], 'river']}
+            paint={{
+              'line-color': '#87CEEB',
+              'line-width': ['interpolate', ['linear'], ['zoom'], 0, 0.5, 5, 1, 10, 1.5, 15, 2],
             }}
           />
         )}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -99,8 +99,9 @@ export const mapFitBoundsMobileConfig = {
 
 /******COLORS******/
 export const plumeOutlineColor = '#FFEA46'
-export const polygonOutlineHoverColor = '#00FF01'
-export const polygonOutlineSelectColor = '#0000FF'
+export const polygonOutlineHoverColor = '#F006'
+//export const polygonOutlineHoverColor = '#ff000066'
+export const polygonOutlineSelectColor = '#f00'
 export const polygonHighlightWidth = 3
 export const topContributingWatershedColorFills = ['#FFA600', '#D86D83', '#7A5195']
 

--- a/src/styles/theme.scss
+++ b/src/styles/theme.scss
@@ -8,6 +8,8 @@ $grey: #dedfe3;
 $greyWhite: #fafbfc;
 $hoverGrey: #f1f2f3;
 $accentBlue: #334bff;
+$activeSelection: #f00;
+$selectionHover: #f006;
 
 /** Fonts, font styling, text **/
 $textColor: #393939;


### PR DESCRIPTION
## Every PR

Before merging, the developer of this pull request has checked the following:

- [x] Changes have been tested locally without errors
- [x] Lint has run and any errors have been resolved
- [x] Prettier has run on any changed files
- [x] Storybook stories have run and any errors have been resolved
- [x] Pre-existing unit tests have run and passed
  - [x] Unit tests have been added or updated, where possible, to prevent future regressions

## Post-Merge

- [ ] Code has merged and build success is confirmed in 'Actions'
- [ ] The corresponding Trello ticket has moved to the appropriate list (likely User-QA)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Rivers are now displayed on the map with light blue styling that dynamically adjusts stroke width based on zoom level.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/data-mermaid/clean-reefs-ui/pull/117?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->