### PR TITLE
C187: Migrate LULC layers from static S3 COGs to TiTiler rastertiles

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -18,18 +18,6 @@ export const COUNTRIES_PMTILES_URL =
 export const WATERSHED_PMTILES_URL =
   'https://d2uu99zl9amnvy.cloudfront.net/assets/gpw_watersheds/gpw_watersheds/visual_watersheds.pmtiles'
 
-/* Land Use Land Cover Layers */
-export const LULC_2000_URL =
-  'https://gpw-coastal-pollution-model-data-public-0001.s3.ap-southeast-2.amazonaws.com/app/global_lulc/lulc_2000_visual.tif'
-export const LULC_2005_URL =
-  'https://gpw-coastal-pollution-model-data-public-0001.s3.ap-southeast-2.amazonaws.com/app/global_lulc/lulc_2005_visual.tif'
-export const LULC_2010_URL =
-  'https://gpw-coastal-pollution-model-data-public-0001.s3.ap-southeast-2.amazonaws.com/app/global_lulc/lulc_2010_visual.tif'
-export const LULC_2015_URL =
-  'https://gpw-coastal-pollution-model-data-public-0001.s3.ap-southeast-2.amazonaws.com/app/global_lulc/lulc_2015_visual.tif'
-export const LULC_2020_URL =
-  'https://gpw-coastal-pollution-model-data-public-0001.s3.ap-southeast-2.amazonaws.com/app/global_lulc/lulc_2020_visual.tif'
-
 /* Benthic Attribute Layers */
 export const ATLAS_BENTHIC_URL = `https://allencoralatlas.org/tiles/benthic/{z}/{x}/{y}?appid=${coralAtlasAppId}`
 export const REEF_EXTENT_URL =

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -63,6 +63,24 @@ export const SEDIMENT_EXPOSURE_2020_URL =
 
 /******TITILER API******/
 export const TITILER_API_BASE_URL = 'https://mermaid.prescient.earth'
+
+/* LULC colormap — 13 entries (0–12) from STAC lulc collection summaries.label:classes.
+   Class 10 ("OUT") forced transparent instead of the STAC hint #FFFFFF. */
+export const LULC_COLORMAP: Record<string, number[]> = {
+  '0': [0, 0, 0, 0],
+  '1': [254, 254, 204, 255],
+  '2': [237, 237, 162, 255],
+  '3': [221, 221, 121, 255],
+  '4': [202, 202, 72, 255],
+  '5': [176, 176, 6, 255],
+  '6': [96, 156, 48, 255],
+  '7': [49, 116, 49, 255],
+  '8': [6, 81, 6, 255],
+  '9': [14, 57, 214, 255],
+  '10': [0, 0, 0, 0],
+  '11': [255, 125, 0, 255],
+  '12': [100, 220, 220, 255],
+}
 export const TITILER_API_TIMEOUT = 10000 // 10 seconds in milliseconds
 export const SED_EXPOSURE_COLLECTION_ID = 'gpw_sediment_exposure'
 export const SED_LOAD_COLLECTION_ID = 'gpw_sediment_load'

--- a/src/data/mapData.ts
+++ b/src/data/mapData.ts
@@ -1,11 +1,6 @@
 import {
   ATLAS_BENTHIC_URL,
   COUNTRIES_PMTILES_URL,
-  LULC_2000_URL,
-  LULC_2005_URL,
-  LULC_2010_URL,
-  LULC_2015_URL,
-  LULC_2020_URL,
   sedExposureBoundaryOutlineColor,
   REEF_EXTENT_URL,
   REGIONS_PMTILES_URL,
@@ -17,6 +12,7 @@ import {
   WATERSHED_PMTILES_URL,
 } from '../constants'
 import { LayerInfo, SubLayerInfo } from '../types/MapDataTypes'
+import { buildLulcTileUrlTemplate } from '../utils/titilerUtils'
 
 export const transparent = 'rgba(0,0,0,0)'
 
@@ -130,11 +126,11 @@ export const layers: LayerInfo[] = [
   },
   reefExtentSubLayer,
   {
-    dataType: 'cog',
+    dataType: 'rastertiles',
     isLayerOn: false,
     layerId: 'lulc',
     legendType: 'lulc',
-    link: LULC_2000_URL,
+    link: buildLulcTileUrlTemplate(2000),
     parentLayerType: 'landcover',
     sourceId: 'lulc_2000_visual',
     sourceFileName: '',
@@ -142,11 +138,11 @@ export const layers: LayerInfo[] = [
     year: 2000,
   },
   {
-    dataType: 'cog',
+    dataType: 'rastertiles',
     isLayerOn: false,
     layerId: 'lulc',
     legendType: 'lulc',
-    link: LULC_2005_URL,
+    link: buildLulcTileUrlTemplate(2005),
     parentLayerType: 'landcover',
     sourceId: 'lulc_2005_visual',
     sourceFileName: '',
@@ -154,11 +150,11 @@ export const layers: LayerInfo[] = [
     year: 2005,
   },
   {
-    dataType: 'cog',
+    dataType: 'rastertiles',
     isLayerOn: false,
     layerId: 'lulc',
     legendType: 'lulc',
-    link: LULC_2010_URL,
+    link: buildLulcTileUrlTemplate(2010),
     parentLayerType: 'landcover',
     sourceId: 'lulc_2010_visual',
     sourceFileName: '',
@@ -166,11 +162,11 @@ export const layers: LayerInfo[] = [
     year: 2010,
   },
   {
-    dataType: 'cog',
+    dataType: 'rastertiles',
     isLayerOn: false,
     layerId: 'lulc',
     legendType: 'lulc',
-    link: LULC_2015_URL,
+    link: buildLulcTileUrlTemplate(2015),
     parentLayerType: 'landcover',
     sourceId: 'lulc_2015_visual',
     sourceFileName: '',
@@ -178,11 +174,11 @@ export const layers: LayerInfo[] = [
     year: 2015,
   },
   {
-    dataType: 'cog',
+    dataType: 'rastertiles',
     isLayerOn: false,
     layerId: 'lulc',
     legendType: 'lulc',
-    link: LULC_2020_URL,
+    link: buildLulcTileUrlTemplate(2020),
     parentLayerType: 'landcover',
     sourceId: 'lulc_2020_visual',
     sourceFileName: '',

--- a/src/utils/titilerUtils.ts
+++ b/src/utils/titilerUtils.ts
@@ -64,7 +64,7 @@ export function buildSedExposureItemId(year: number): string {
 export function buildLulcTileUrlTemplate(year: number): string {
   const basePath = `${TITILER_API_BASE_URL}/raster/collections/lulc/items/lulc_${year}/tiles/WebMercatorQuad/{z}/{x}/{y}.png`
   const params = new URLSearchParams({
-    assets: 'cog',
+    assets: 'Land Use and Land Cover Collection Cloud Optimized GeoTIFF',
     colormap: JSON.stringify(LULC_COLORMAP),
   })
   return `${basePath}?${params.toString()}`

--- a/src/utils/titilerUtils.ts
+++ b/src/utils/titilerUtils.ts
@@ -4,6 +4,7 @@ import {
   TITILER_API_TIMEOUT,
   SED_EXPOSURE_COLLECTION_ID,
   SED_LOAD_COLLECTION_ID,
+  LULC_COLORMAP,
 } from '../constants'
 
 export interface ExpressionConfig {
@@ -57,6 +58,16 @@ export function buildSedExposureExpression(region: RegionOption): ExpressionConf
 /** Build the TiTiler item ID for the selected year. */
 export function buildSedExposureItemId(year: number): string {
   return `${SED_EXPOSURE_COLLECTION_ID}_${year}`
+}
+
+/** Build a MapLibre-compatible LULC tile URL template for the given year. */
+export function buildLulcTileUrlTemplate(year: number): string {
+  const basePath = `${TITILER_API_BASE_URL}/raster/collections/lulc/items/lulc_${year}/tiles/WebMercatorQuad/{z}/{x}/{y}.png`
+  const params = new URLSearchParams({
+    assets: 'cog',
+    colormap: JSON.stringify(LULC_COLORMAP),
+  })
+  return `${basePath}?${params.toString()}`
 }
 
 /**


### PR DESCRIPTION
## What changed:
- Land use / land cover (LULC) layers now load tiles from the MERMAID TiTiler STAC collection instead of static AWS S3 COG files
- Each year's LULC layer switches from `dataType: 'cog'` to `dataType: 'rastertiles'` — MapLibre fetches pre-rendered XYZ tiles rather than decoding COGs client-side
- A `buildLulcTileUrlTemplate(year)` helper builds the TiTiler tile URL with the correct asset key and RGBA colormap (13 land-cover classes; classes 0 and 10 forced transparent)
- The 5 static AWS S3 `LULC_*_URL` constants are removed; `LULC_COLORMAP` is added to `constants.ts`

## Every PR

Before merging, the developer of this pull request has checked the following:

- [x] Changes have been tested locally without errors
- [x] Lint has run and any errors have been resolved
- [x] Prettier has run on any changed files
- [x] Storybook stories have run and any errors have been resolved
- [x] Pre-existing unit tests have run and passed
  - [ ] Unit tests have been added or updated, where possible, to prevent future regressions

## Post-Merge

- [ ] Code has merged and build success is confirmed in 'Actions'
- [ ] The corresponding Trello ticket has moved to the appropriate list (likely User-QA)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated land-use/cover layer tile generation with customized color mapping for enhanced rendering consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->